### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,8 +5,8 @@ Always reference these instructions first and fall back to search or bash comman
 ## Working Effectively
 
 ### Prerequisites and Setup
-- Install Go 1.26.0 (as specified in `go.mod`)
-- Install Terraform 1.10.4+
+- Install Go 1.26.2 (as specified in `go.mod`)
+- Install Terraform 1.11+ (required for WriteOnly attributes introduced in v3.0.0)
 - Install make for build automation
 
 ### Essential Build and Test Commands
@@ -27,13 +27,13 @@ Always reference these instructions first and fall back to search or bash comman
 
 ### Manual Provider Testing
 - Always run `make install` before testing provider changes
-- Create test Terraform configuration in `/tmp/tf-test/main.tf`:
+- Create test Terraform configuration in `/tmp/tf-test/main.tf`. The version must match the `VERSION` used by `make install` (auto-detected from the latest git tag, e.g. `3.0.5`):
 ```hcl
 terraform {
   required_providers {
     http = {
       source = "hashicorp-local.com/rios0rios0/http"
-      version = "2.3.0"
+      version = "3.0.5" # must match the VERSION from `make install`
     }
   }
 }
@@ -62,7 +62,7 @@ resource "http_request" "test_request" {
 1. **Build and Install**: `make build && make install` -- must complete without errors
 2. **Test Suite**: `make test` -- all tests must pass with a coverage report
 3. **Linting**: `make lint` -- all linting issues must be resolved
-4. **Provider Installation**: Local provider must install to `~/.terraform.d/plugins/hashicorp-local.com/rios0rios0/http/2.3.0/linux_amd64/`
+4. **Provider Installation**: Local provider must install to `~/.terraform.d/plugins/hashicorp-local.com/rios0rios0/http/$(VERSION)/linux_amd64/`
 5. **Terraform Integration**: `terraform init` and `terraform plan` must work with local provider
 6. **Documentation**: `make docs` must generate clean documentation in `docs/` directory
 7. **CHANGELOG.md**: **ALWAYS update CHANGELOG.md** with changes in the `[Unreleased]` section
@@ -95,13 +95,15 @@ resource "http_request" "test_request" {
 - Basic authentication and TLS options (configurable at both provider and resource level)
 - Query parameters and request body support
 - State management with response storage
-- Delete operations with path resolution (`is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers`, `delete_request_body`, `delete_resolved_path`)
+- Delete operations with path resolution (`is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers`, `delete_request_body`, `delete_resolved_path`). Since v3.0.0 these are WriteOnly attributes (not persisted in state; stored in provider private state)
+- `tolerated_status_codes` attribute to treat specific non-2xx HTTP status codes as successful
 - `ignore_changes` attribute to suppress diffs for specific resource attributes during updates
 - Resource-level configuration (`base_url`, `basic_auth`, `ignore_tls`) to support `count`/`for_each` with different APIs
 - State importing via Base64-encoded JSON (`terraform import`)
 
 ### Version and Configuration
-- Current version: 2.3.0 (defined in `main.go` and `Makefile`)
+- Version is auto-detected from the latest git tag via `ldflags` at build time (defaults to `dev` when no tag is present). See `VERSION` in `Makefile`.
+- Schema version: 1 (upgraded from 0 in v3.0.0; state upgrade runs automatically)
 - Provider address: `registry.terraform.io/rios0rios0/http`
 - Local testing address: `hashicorp-local.com/rios0rios0/http`
 
@@ -117,7 +119,7 @@ resource "http_request" "test_request" {
 
 ### Provider Installation Issues
 - Local provider isn't found: Ensure `make install` completed successfully
-- Version mismatches: Check version in `main.go` and `Makefile` match version in test configurations
+- Version mismatches: Run `git describe --tags --abbrev=0` to see the VERSION that `make install` will use, and match it in test configurations
 
 ## External Dependencies
 - Uses external CI pipeline: `rios0rios0/pipelines/.github/workflows/go-binary.yaml@main` (in `.github/workflows/default.yaml`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, architecture overview, and key conventions for Claude Code sessions
+
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` to reflect v3.x state: Go 1.26.2, Terraform 1.11+, auto-detected version via ldflags, WriteOnly delete attributes, and `tolerated_status_codes`
 - changed the Go module dependencies to their latest versions
 
 ## [3.0.6] - 2026-04-24

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Test Commands
+
+- `make build` — compiles the provider binary with ldflags version injection
+- `make install` — builds and installs to `~/.terraform.d/plugins/hashicorp-local.com/rios0rios0/http/$(VERSION)/linux_amd64/`
+- `make test` — runs full test suite with coverage (uses external script from `rios0rios0/pipelines`)
+- `make lint` — runs golangci-lint via the pipelines project's shared config
+- `make lint-fix` — lint with auto-fix
+- `make docs` — generates Terraform plugin docs (requires `terraform` in PATH; may need `export GOBIN=$PWD/bin && export PATH=$GOBIN:$PATH`)
+- `make semgrep` / `make gitleaks` — security scanning via pipelines scripts
+
+VERSION is auto-detected from the latest git tag (`git describe --tags --abbrev=0`), falling back to `dev`.
+
+## Architecture
+
+Terraform provider using the Plugin Framework (not the older SDK). Follows a DDD-inspired layout:
+
+- `main.go` — entry point; version injected via `-ldflags`
+- `internal/provider/` — Terraform resource and provider schemas, CRUD logic, validators
+- `internal/domain/entities/` — domain models (`Configuration`, `InternalContext`)
+- `internal/infrastructure/helpers/` — HTTP client, mapper, and resource helper utilities
+- `internal/infrastructure/validators/` — custom schema validators (e.g. `StringNotEmpty`)
+- `test/infrastructure/builders/` — test helpers for constructing provider/resource configs
+- `tools/tools.go` — tool dependencies pinned for `go generate` (e.g. `tfplugindocs`)
+
+## Key Conventions
+
+- Always update `CHANGELOG.md` under `[Unreleased]` when making changes.
+- Delete-operation attributes (`is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers`, `delete_request_body`) are WriteOnly (Terraform 1.11+). They are not persisted in Terraform state; values are stored in provider private state. Schema version is 1.
+- `Makefile` targets delegate to scripts in the external `rios0rios0/pipelines` repo (cloned to `~/Development/github.com/rios0rios0/pipelines`).
+- CI runs `rios0rios0/pipelines/.github/workflows/go-binary.yaml@main`. Releases use GoReleaser with GPG signing on `v*` tags.
+- Tests hit `jsonplaceholder.typicode.com` for integration testing. Acceptance tests need `TF_ACC_PROVIDER_NAMESPACE=rios0rios0`.
+
+## Requirements
+
+- Go 1.26.2+
+- Terraform 1.11+


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.