### PR TITLE
feat(ci): enabled GPG signing in delivery-binary

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -21,3 +21,7 @@ jobs:
     uses: 'rios0rios0/pipelines/.github/workflows/go-binary.yaml@main'
     with:
       binary_name: 'terraform-provider-http'
+      gpg_sign: true
+    secrets:
+      gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
+      gpg_passphrase: '${{ secrets.GPG_PASSPHRASE }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed silent regression where every release since `3.0.0` (2026-03-31) shipped with zero assets, because the repo's `.goreleaser.yml` declares a `signs:` block referencing `{{ .Env.GPG_FINGERPRINT }}` but the shared `delivery-binary` action never imported a GPG key or populated that env var. GoReleaser failed at `signing artifacts` and uploaded nothing — leaving Terraform Registry with empty release pages for `3.0.0`, `3.0.1`, `3.0.2`, `3.0.3`, `3.0.4`, `3.0.5`, and `3.1.0`. Wired `gpg_sign: true` into the `go-binary.yaml` reusable workflow and forwarded the existing repo secrets `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`. The new `crazy-max/ghaction-import-gpg@v6` step ([added in pipelines PR #388](https://github.com/rios0rios0/pipelines/pull/388)) imports the key and exposes its fingerprint to GoReleaser as `GPG_FINGERPRINT` at runtime, so no `GPG_FINGERPRINT` secret needs to be maintained in sync with the private key
+
 ## [3.1.0] - 2026-04-28
 
 ### Added


### PR DESCRIPTION
## Summary

Wires `gpg_sign: true` and forwards the existing repo secrets `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` into the `go-binary.yaml` reusable workflow.

## Why

This repo's `.goreleaser.yml` declares a `signs:` block referencing `{{ .Env.GPG_FINGERPRINT }}` — mandatory for Terraform Registry, which refuses providers without a `_SHA256SUMS.sig`. Since the migration to `go-binary.yaml@main` at `3.0.0` (2026-03-31), the shared `delivery-binary` action never imported a GPG key or populated that env var, so GoReleaser failed at `signing artifacts` on every run and **uploaded zero assets** — silently. `3.0.0`, `3.0.1`, `3.0.2`, `3.0.3`, `3.0.4`, `3.0.5`, and `3.1.0` are all empty release pages on GitHub and on the Terraform Registry.

## What changed

- Set `gpg_sign: true` on the reusable workflow call.
- Forwarded the repo secrets `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` (already present in this repo's settings; no new secrets to provision).
- Documented the fix under `### Fixed` in `CHANGELOG.md`.

## Dependency

Requires https://github.com/rios0rios0/pipelines/pull/388 to be merged first — that PR adds the `gpg_sign` input + GPG import step to `go-binary.yaml` and the binary delivery action.

## Test plan

- [ ] After both PRs merge: open a tiny no-op bump on `main` and confirm the workflow run uploads `*_SHA256SUMS`, `*_SHA256SUMS.sig`, and the per-OS provider zips
- [ ] Confirm Terraform Registry picks up the next signed release
- [ ] Out-of-band recovery PR/script will re-fire the on-tag workflow for `3.0.0` through `3.1.0` so their release pages get populated retroactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)