### PR TITLE
fix(ci): used the actual repo-secret name PASSPHRASE for gpg_passphrase

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -24,4 +24,4 @@ jobs:
       gpg_sign: true
     secrets:
       gpg_private_key: '${{ secrets.GPG_PRIVATE_KEY }}'
-      gpg_passphrase: '${{ secrets.GPG_PASSPHRASE }}'
+      gpg_passphrase: '${{ secrets.PASSPHRASE }}'


### PR DESCRIPTION
## Summary

PR #86 forwarded `secrets.GPG_PASSPHRASE`, but the repo's actual secret is named just `PASSPHRASE` (created 2024-08-24 alongside `GPG_PRIVATE_KEY`).

Verified with `gh secret list --repo rios0rios0/terraform-provider-http`:

```
GPG_PRIVATE_KEY    2024-08-24T00:30:13Z
PASSPHRASE         2024-08-24T00:30:20Z
```

## Why this matters

Without the rename, every recovery run for releases `3.0.0` through `3.1.0` failed at the new validation step landed in [pipelines PR #388](https://github.com/rios0rios0/pipelines/pull/388) with:

```
##[error]gpg_sign is 'true' but gpg_passphrase is empty.
   GPG_PRIVATE_KEY: ***   ← present, masked
   GPG_PASSPHRASE:        ← empty (because secrets.GPG_PASSPHRASE doesn't exist)
```

After this PR merges, I'll re-fire the 7 recovery workflows by recreating the tags at HEAD, and they should produce signed binaries this time.

## Test plan

- [x] Confirmed secret name via `gh secret list`
- [ ] After merge: re-tag `3.0.0` … `3.1.0` at HEAD; confirm `*_SHA256SUMS.sig` lands on each release

🤖 Generated with [Claude Code](https://claude.com/claude-code)