### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
-      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           args: release --clean
         env:


### PR DESCRIPTION
## Summary

Bumps GitHub Actions to their latest versions. Addresses the upcoming [deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced Node 24 default on June 2, 2026; Node 20 removed September 16, 2026) and brings third-party actions to current majors.

### Updates applied

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v2 / v4 / v5 / pinned | **v6** / pinned to v6.0.2 |
| `actions/cache` | v1 / pinned | **v5** / pinned to v5.0.5 |
| `actions/setup-go` | v5 / pinned | **v6** / pinned to v6.4.0 |
| `actions/setup-node` | v4 / pinned | **v6** / pinned to v6.4.0 |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 / v6 / pinned | **v7** / pinned to v7.0.1 |
| `actions/download-artifact` | v4 | **v8** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/configure-pages` | v5 | **v6** |
| `actions/dependency-review-action` | pinned v4.8.3 | pinned to v4.9.0 |
| `actions/github-script` | pinned v8.0.0 | pinned to v9.0.0 |
| `actions/stale` | v3 / pinned v9 | **v10** / pinned to v10.2.0 |
| `crazy-max/ghaction-import-gpg` | v6 / pinned | **v7** / pinned to v7.0.0 |
| `dorny/test-reporter` | v1 | **v3** |
| `pnpm/action-setup` | v4 | **v5** |
| `softprops/action-gh-release` | v1 / v2 / pinned | **v3** / pinned to v3.0.0 |
| `goreleaser/goreleaser-action` | v6 / pinned | **v7** / pinned to v7.2.1 |
| `jdx/mise-action` | pinned v3 | pinned to v4.0.1 |
| `docker/build-push-action` | v5 / v6 | **v7** |
| `docker/login-action` | v1 / v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/setup-qemu-action` | v3 | **v4** |
| `step-security/harden-runner` | pinned v2.15.0 | pinned to v2.19.0 |
| `azohra/shell-linter` | `@latest` (unpinned!) | **v0.8.0** |

### Heads-up — major-version bumps to verify

These had breaking changes between majors and may need workflow tweaks. Review before merging:

- **`actions/upload-artifact` v4 → v7** and **`download-artifact` v4 → v8** — v4 changed artifact immutability and naming; v5+ requires unique artifact names per upload.
- **`softprops/action-gh-release` v1/v2 → v3** — input schema changes in v3.
- **`dorny/test-reporter` v1 → v3** — config inputs may have changed.
- **`pnpm/action-setup` v4 → v5** — verify Node setup ordering still works.
- **`goreleaser-action` v6 → v7** — requires GoReleaser v2.
- **`actions/stale` v3 → v10** — large gap; verify input names.

## Test plan

- [ ] Verify each affected workflow runs successfully on this branch
- [ ] Confirm artifact upload/download still succeeds where applicable
- [ ] Confirm release workflows publish correctly (where touched)
- [ ] Spot-check Docker build & push if Docker stages were updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
