### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ Always reference these instructions first and fall back to search or bash comman
 ## Working Effectively
 
 ### Prerequisites and Setup
-- Install Go 1.26.3 (as specified in `go.mod`)
+- Install Go 1.26.4 (as specified in `go.mod`)
 - Install Terraform 1.11+ (required for WriteOnly attributes introduced in v3.0.0)
 - Install make for build automation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to reference Go `1.26.4` to match `go.mod`
+
 ## [3.1.8] - 2026-06-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,5 +36,5 @@ Terraform provider using the Plugin Framework (not the older SDK). Follows a DDD
 
 ## Requirements
 
-- Go 1.26.3+
+- Go 1.26.4+
 - Terraform 1.11+


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.