### PR TITLE
fix(state): carry WriteOnly delete attributes as typed nulls in the v0->v1 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `http_request` failing the first `plan` after a `2.x` state (schema `v0`) is upgraded to `3.x`, with `Error: Value Conversion Error ... Path: delete_headers` (`Map[!!! MISSING TYPE !!!]` / `tftypes.Map[tftypes.DynamicPseudoType]`). The schema `v0`->`v1` state upgrader rebuilt the model without the new WriteOnly delete-control attributes, so `delete_headers` took Go's zero-value `types.Map{}` (element-typeless) instead of a typed null. The upgrader now sets `is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers` (`types.MapNull(types.StringType)`), and `delete_request_body` to typed nulls. Affects every configuration that upgrades pre-`3.0.0` state — the resource was un-plannable on `3.0.0`-`3.1.9` until the state was recreated
+
 ## [3.1.9] - 2026-06-09
 
 ### Changed

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -785,6 +785,18 @@ func (it *HTTPRequestResource) UpgradeState(_ context.Context) map[int64]resourc
 					ResponseBody:         oldModel.ResponseBody,
 					ResponseBodyID:       oldModel.ResponseBodyID,
 					ResponseBodyJSON:     oldModel.ResponseBodyJSON,
+
+					// The delete-control attributes became WriteOnly in schema v1. They must be
+					// carried as TYPED nulls here -- leaving them as the struct's zero value gives
+					// DeleteHeaders an element-typeless types.Map{}, which makes the very next plan
+					// fail with "Value Conversion Error ... Path: delete_headers"
+					// (Map[!!! MISSING TYPE !!!] / Map[DynamicPseudoType]). WriteOnly values are
+					// never persisted, so null is the correct upgraded-state value.
+					IsDeleteEnabled:   types.BoolNull(),
+					DeleteMethod:      types.StringNull(),
+					DeletePath:        types.StringNull(),
+					DeleteHeaders:     types.MapNull(types.StringType),
+					DeleteRequestBody: types.StringNull(),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, newModel)...)


### PR DESCRIPTION
## Summary

Fixes the `http_request` resource being **un-plannable on `3.0.0`–`3.1.9`** for anyone upgrading from pre-`3.0.0` (`2.x`) state. The first `plan` after the provider upgrade fails with:

```
Error: Value Conversion Error
  Path: delete_headers
  Expected ... types.MapType[basetypes.StringType] / tftypes.Map[tftypes.String]
  Received ... types.MapType[!!! MISSING TYPE !!!] / tftypes.Map[tftypes.DynamicPseudoType]
```

## Root cause

The schema `v0`→`v1` `StateUpgrader` (added when the delete-control attributes became WriteOnly in `3.0.0`) rebuilds the model but **omits the five new delete fields**. `DeleteHeaders` therefore takes Go's zero value `types.Map{}`, which has no element type, so the upgraded state carries a typeless `Map[DynamicPseudoType]` and the immediately-following plan fails type verification. Only the **map** trips it — the scalar delete fields tolerate a zero-value null.

This only reproduces against **existing `2.x` state** (the upgrade path), which is why a fresh `plan` looks fine.

## Fix

Set the WriteOnly delete attributes to typed nulls in the upgraded model (`delete_headers` → `types.MapNull(types.StringType)`). WriteOnly values are never persisted, so null is the correct upgraded value.

## Validation

- Reproduced the exact error on registry `3.0.5` planning against a state created by `2.2.0` (schema v0).
- Confirmed a **clean plan** with the fixed build on the same v0 state (`No changes`).
- `go test ./...`, `go vet`, `gofmt` all clean.

Follow-up: the repo has no unit test for the state upgrader; a regression test asserting a typed-null `delete_headers` after the v0→v1 upgrade would be worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
