### PR TITLE
chore(bump): bumped version to 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [3.1.10] - 2026-06-15
+
 ### Changed
 
 - changed the Go module dependencies to their latest versions


### PR DESCRIPTION
## 3.1.10

Bumped by `autobump`. Ships:

- **Fixed** — the `delete_headers` v0→v1 state-upgrade crash (#131): `http_request` was un-plannable on `3.0.0`–`3.1.9` against any pre-`3.0.0` state, because the schema upgrader left `delete_headers` as a typeless `types.Map{}`. Validated against real `2.2.0` state.
- **Changed** — dependency refresh.

After merge, **create the `3.1.10` git tag** to trigger the signed GoReleaser publish (`VERSION` auto-detects from the tag).

> Note: the registry currently stops at `3.1.7` — the `3.1.8`/`3.1.9` CHANGELOG sections were never tagged — so tagging `3.1.10` folds their content in too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
