### PR TITLE
fix(resource): re-issue the request only when a request-defining attribute changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ resource "http_request" "test_request" {
   - `provider.go` -- provider configuration and setup
   - `resource_http_request.go` -- main HTTP request resource
   - `ignore_changes_helper.go` -- `ignore_changes` feature implementation
-  - `*_test.go` -- comprehensive test files with unit and integration tests (including `resource_http_request_ignore_test.go`)
+  - `*_test.go` -- comprehensive test files with unit and integration tests (including `resource_http_request_ignore_test.go` and the update re-issue regression tests in `resource_http_request_reissue_test.go` / `resource_http_request_reissue_integration_test.go`)
 - `internal/domain/entities/` -- domain entities and business logic (`Configuration`, `InternalContext`)
 - `internal/infrastructure/helpers/` -- HTTP, mapper, and resource helper utilities
 - `internal/infrastructure/validators/` -- custom validators (e.g. `StringNotEmpty`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,18 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added regression tests for the in-place update re-issue behavior: a unit test asserting that only request-defining attribute changes trigger a re-issue, and integration tests (driven by a local endpoint that returns a fresh id per request) proving that a client-side-only change neither re-issues the request nor fails apply, that a genuine request change still re-issues consistently, and that write-only destroy controls enabled in the same apply as a client-side-only change are still honored on destroy
+
 ### Changed
 
 - changed the Go module dependencies to their latest versions
 
 ### Fixed
 
-- fixed `http_request` failing an in-place update with `Error: Provider produced inconsistent result after apply` when only a client-side attribute changed (for example `tolerated_status_codes`). `Update` unconditionally re-issued the request, but the computed response attributes (`id`, `response_code`, `response_body`, `response_body_id`, `response_body_json`) carry `UseStateForUnknown`, so the plan pinned them to their prior values while the re-issued request returned a different response — and for a non-idempotent method the request was repeated needlessly. The request is now re-issued only when an attribute that defines it actually changes (`method`, `path`, `headers`, `request_body`, `query_parameters`, `base_url`, `basic_auth`, `ignore_tls`); a change limited to response-interpretation attributes keeps the recorded response untouched. When the request does change, those computed attributes are planned as unknown so the freshly captured response is accepted — which also resolves the same inconsistency for legitimate `request_body` / `headers` / etc. edits
+- fixed `http_request` failing an in-place update with `Error: Provider produced inconsistent result after apply` when only a client-side attribute changed (for example `tolerated_status_codes`). `Update` unconditionally re-issued the request, but the computed response attributes (`id`, `response_code`, `response_body`, `response_body_id`, `response_body_json`, `delete_resolved_path`) carry `UseStateForUnknown`, so the plan pinned them to their prior values while the re-issued request returned a different response — and for a non-idempotent method the request was repeated needlessly. The request is now re-issued only when an attribute that defines it actually changes (`method`, `path`, `headers`, `request_body`, `query_parameters`, `base_url`, `basic_auth`, `ignore_tls`); a change limited to response-interpretation attributes keeps the recorded response untouched. When the request does change, those computed attributes (including `delete_resolved_path`) are planned as unknown so the freshly captured response is accepted — which also resolves the same inconsistency for legitimate `request_body` / `headers` / etc. edits
+- fixed `terraform destroy` not honoring write-only destroy controls (`is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers`, `delete_request_body`) that were changed in the same apply as a client-side-only update. Because those attributes are read only from configuration and persisted in opaque private state, the short-circuiting update path now refreshes them into private state just like a full create/update, so a later destroy uses the current delete configuration instead of the stale one
 
 ## [3.1.10] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - changed the Go module dependencies to their latest versions
 
+### Fixed
+
+- fixed `http_request` failing an in-place update with `Error: Provider produced inconsistent result after apply` when only a client-side attribute changed (for example `tolerated_status_codes`). `Update` unconditionally re-issued the request, but the computed response attributes (`id`, `response_code`, `response_body`, `response_body_id`, `response_body_json`) carry `UseStateForUnknown`, so the plan pinned them to their prior values while the re-issued request returned a different response — and for a non-idempotent method the request was repeated needlessly. The request is now re-issued only when an attribute that defines it actually changes (`method`, `path`, `headers`, `request_body`, `query_parameters`, `base_url`, `basic_auth`, `ignore_tls`); a change limited to response-interpretation attributes keeps the recorded response untouched. When the request does change, those computed attributes are planned as unknown so the freshly captured response is accepted — which also resolves the same inconsistency for legitimate `request_body` / `headers` / etc. edits
+
 ## [3.1.10] - 2026-06-15
 
 ### Changed

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -474,8 +474,24 @@ func (it *HTTPRequestResource) Update(
 	// recorded response and, for a non-idempotent method, repeat the side effect. In that
 	// case the plan already carries the captured response forward via UseStateForUnknown,
 	// so persist it unchanged instead of producing an inconsistent result after apply.
-	if !requestAttributesChanged(planModel, stateModel) {
+	if !RequestAttributesChanged(planModel, stateModel) {
+		// Write-only delete-control attributes are nullified in plan and state, so re-read
+		// them from config (as Create does) and refresh them into private state. Skipping
+		// this would leave a later Destroy running with stale delete configuration when only
+		// a client-side attribute changed.
+		var configModel HTTPRequestResourceModel
+		resp.Diagnostics.Append(req.Config.Get(ctx, &configModel)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		planModel.IsDeleteEnabled = configModel.IsDeleteEnabled
+		planModel.DeleteMethod = configModel.DeleteMethod
+		planModel.DeletePath = configModel.DeletePath
+		planModel.DeleteHeaders = configModel.DeleteHeaders
+		planModel.DeleteRequestBody = configModel.DeleteRequestBody
+
 		resp.Diagnostics.Append(resp.State.Set(ctx, &planModel)...)
+		resp.Diagnostics.Append(marshalDeleteParamsToPrivate(ctx, planModel, resp.Private)...)
 		return
 	}
 
@@ -486,12 +502,12 @@ func (it *HTTPRequestResource) Update(
 	}, (*resource.CreateResponse)(resp))
 }
 
-// requestAttributesChanged reports whether any attribute that defines the outgoing HTTP
+// RequestAttributesChanged reports whether any attribute that defines the outgoing HTTP
 // request differs between the plan and the prior state. Response-interpretation attributes
 // (tolerated_status_codes, response_body_id_filter, is_response_body_json), ignore_changes,
 // the computed response attributes, and the write-only destroy controls are intentionally
 // excluded -- changing any of them does not change the request that was sent.
-func requestAttributesChanged(plan, state HTTPRequestResourceModel) bool {
+func RequestAttributesChanged(plan, state HTTPRequestResourceModel) bool {
 	return !plan.Method.Equal(state.Method) ||
 		!plan.Path.Equal(state.Path) ||
 		!plan.Headers.Equal(state.Headers) ||
@@ -542,14 +558,17 @@ func (it *HTTPRequestResource) ModifyPlan(
 	// captured response changes with it. The computed attributes carry UseStateForUnknown,
 	// which would otherwise pin them to their stale values and fail apply with "Provider
 	// produced inconsistent result after apply"; mark them unknown so the freshly captured
-	// response is accepted. A change limited to client-side attributes leaves the recorded
-	// response untouched, so the pinned values stay correct.
-	if requestAttributesChanged(planModel, stateModel) {
+	// response is accepted. delete_resolved_path is included because it is recomputed from
+	// the response in populateResponseState and is likewise UseStateForUnknown. A change
+	// limited to client-side attributes leaves the recorded response untouched, so the
+	// pinned values stay correct.
+	if RequestAttributesChanged(planModel, stateModel) {
 		planModel.ID = types.StringUnknown()
 		planModel.ResponseCode = types.Int32Unknown()
 		planModel.ResponseBody = types.StringUnknown()
 		planModel.ResponseBodyID = types.StringUnknown()
 		planModel.ResponseBodyJSON = types.MapUnknown(types.StringType)
+		planModel.DeleteResolvedPath = types.StringUnknown()
 	}
 
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &planModel)...)

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -459,11 +459,47 @@ func (it *HTTPRequestResource) Update(
 	req resource.UpdateRequest,
 	resp *resource.UpdateResponse,
 ) {
+	var planModel HTTPRequestResourceModel
+	var stateModel HTTPRequestResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planModel)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateModel)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Only re-issue the HTTP request when an attribute that defines the request actually
+	// changed. Response-interpretation attributes (tolerated_status_codes,
+	// response_body_id_filter, is_response_body_json) and ignore_changes do not alter the
+	// outgoing request, so changing one must not re-send it: re-sending would discard the
+	// recorded response and, for a non-idempotent method, repeat the side effect. In that
+	// case the plan already carries the captured response forward via UseStateForUnknown,
+	// so persist it unchanged instead of producing an inconsistent result after apply.
+	if !requestAttributesChanged(planModel, stateModel) {
+		resp.Diagnostics.Append(resp.State.Set(ctx, &planModel)...)
+		return
+	}
+
 	it.Create(ctx, resource.CreateRequest{
 		Config:       req.Config,
 		Plan:         req.Plan,
 		ProviderMeta: req.ProviderMeta,
 	}, (*resource.CreateResponse)(resp))
+}
+
+// requestAttributesChanged reports whether any attribute that defines the outgoing HTTP
+// request differs between the plan and the prior state. Response-interpretation attributes
+// (tolerated_status_codes, response_body_id_filter, is_response_body_json), ignore_changes,
+// the computed response attributes, and the write-only destroy controls are intentionally
+// excluded -- changing any of them does not change the request that was sent.
+func requestAttributesChanged(plan, state HTTPRequestResourceModel) bool {
+	return !plan.Method.Equal(state.Method) ||
+		!plan.Path.Equal(state.Path) ||
+		!plan.Headers.Equal(state.Headers) ||
+		!plan.RequestBody.Equal(state.RequestBody) ||
+		!plan.QueryParameters.Equal(state.QueryParameters) ||
+		!plan.BaseURL.Equal(state.BaseURL) ||
+		!plan.BasicAuth.Equal(state.BasicAuth) ||
+		!plan.IgnoreTLS.Equal(state.IgnoreTLS)
 }
 
 func (it *HTTPRequestResource) ModifyPlan(
@@ -487,16 +523,33 @@ func (it *HTTPRequestResource) ModifyPlan(
 		return
 	}
 
+	// Honor ignore_changes first so the request-change check below reflects the effective
+	// plan (an ignored request attribute must not count as a change).
 	entries := parseIgnoreEntries(ctx, planModel.IgnoreChanges, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() || len(entries) == 0 {
-		return
-	}
-
-	if !applyIgnoreEntries(ctx, entries, &planModel, &stateModel, &resp.Diagnostics) {
-		return
-	}
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	if len(entries) > 0 {
+		if !applyIgnoreEntries(ctx, entries, &planModel, &stateModel, &resp.Diagnostics) {
+			return
+		}
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	// When a request-defining attribute changes, Update re-issues the request and the
+	// captured response changes with it. The computed attributes carry UseStateForUnknown,
+	// which would otherwise pin them to their stale values and fail apply with "Provider
+	// produced inconsistent result after apply"; mark them unknown so the freshly captured
+	// response is accepted. A change limited to client-side attributes leaves the recorded
+	// response untouched, so the pinned values stay correct.
+	if requestAttributesChanged(planModel, stateModel) {
+		planModel.ID = types.StringUnknown()
+		planModel.ResponseCode = types.Int32Unknown()
+		planModel.ResponseBody = types.StringUnknown()
+		planModel.ResponseBodyID = types.StringUnknown()
+		planModel.ResponseBodyJSON = types.MapUnknown(types.StringType)
 	}
 
 	resp.Diagnostics.Append(resp.Plan.Set(ctx, &planModel)...)

--- a/internal/provider/resource_http_request_reissue_integration_test.go
+++ b/internal/provider/resource_http_request_reissue_integration_test.go
@@ -1,0 +1,227 @@
+//go:build integration
+
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/rios0rios0/terraform-provider-http/test/infrastructure/builders"
+)
+
+// reissueTracker is a tiny in-memory HTTP endpoint used to detect whether the
+// provider re-issued the outgoing request. Every non-DELETE call returns a fresh
+// incrementing id, so a re-issue is observable as a changed response_body_id.
+// DELETE calls are recorded so destroy behaviour can be asserted.
+type reissueTracker struct {
+	mu          sync.Mutex
+	createCount int
+	deletePaths []string
+}
+
+func newReissueServer(t *testing.T) (*httptest.Server, *reissueTracker) {
+	t.Helper()
+
+	tracker := &reissueTracker{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tracker.mu.Lock()
+		defer tracker.mu.Unlock()
+
+		if r.Method == http.MethodDelete {
+			tracker.deletePaths = append(tracker.deletePaths, r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+
+		tracker.createCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"id":"%d"}`, tracker.createCount)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, tracker
+}
+
+func (rt *reissueTracker) creates() int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.createCount
+}
+
+func (rt *reissueTracker) deleted(path string) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, p := range rt.deletePaths {
+		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHTTPRequestResource_ReissueRegression guards the "Provider produced inconsistent
+// result after apply" bug: an in-place update that changes only a client-side attribute
+// (for example tolerated_status_codes) must not re-issue the request, while a genuine
+// request change still re-issues and stays consistent.
+func TestHTTPRequestResource_ReissueRegression(t *testing.T) {
+	t.Run("should not re-issue or fail apply when only a client-side attribute changes", func(t *testing.T) {
+		// given
+		srv, tracker := newReissueServer(t)
+		providerConfig := builders.NewProviderTFBuilder().WithURL(srv.URL).Build()
+
+		create := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			Build()
+
+		// Adding tolerated_status_codes is a client-side-only change. Before the fix this
+		// re-issued the request (changing the captured id) and could fail apply with
+		// "Provider produced inconsistent result after apply".
+		addTolerated := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			WithToleratedStatusCodes([]int{404}).
+			Build()
+
+		// when / then
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: create,
+					Check:  resource.TestCheckResourceAttr("http_request.reissue", "response_body_id", "1"),
+				},
+				{
+					Config: addTolerated,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("http_request.reissue", "response_body_id", "1"),
+						resource.TestCheckTypeSetElemAttr("http_request.reissue", "tolerated_status_codes.*", "404"),
+					),
+				},
+			},
+		})
+
+		// then
+		if got := tracker.creates(); got != 1 {
+			t.Fatalf("expected exactly 1 outgoing request (no re-issue), got %d", got)
+		}
+	})
+
+	t.Run("should re-issue and stay consistent when a request attribute changes", func(t *testing.T) {
+		// given
+		srv, tracker := newReissueServer(t)
+		providerConfig := builders.NewProviderTFBuilder().WithURL(srv.URL).Build()
+
+		create := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue_real").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			Build()
+
+		// Adding a query parameter changes the outgoing request, so the provider must
+		// re-issue it and accept the freshly captured response.
+		changeRequest := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue_real").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			WithQueryParameters(map[string]string{"x": "1"}).
+			Build()
+
+		// when / then
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: create,
+					Check:  resource.TestCheckResourceAttr("http_request.reissue_real", "response_body_id", "1"),
+				},
+				{
+					Config: changeRequest,
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("http_request.reissue_real", "response_body_id", "2"),
+						resource.TestCheckResourceAttr("http_request.reissue_real", "query_parameters.x", "1"),
+					),
+				},
+			},
+		})
+
+		// then
+		if got := tracker.creates(); got != 2 {
+			t.Fatalf("expected 2 outgoing requests (initial + re-issue), got %d", got)
+		}
+	})
+
+	t.Run("should refresh delete controls into private state during a client-side-only update", func(t *testing.T) {
+		// given -- create with deletion disabled, so private state initially carries
+		// is_delete_enabled = false.
+		srv, tracker := newReissueServer(t)
+		providerConfig := builders.NewProviderTFBuilder().WithURL(srv.URL).Build()
+
+		create := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue_delete").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			Build()
+
+		// A client-side-only change (tolerated_status_codes) drives an in-place Update while
+		// it simultaneously enables deletion. The write-only delete controls must be refreshed
+		// from config into private state during the short-circuit, or the later Destroy would
+		// skip the DELETE.
+		enableDelete := providerConfig + builders.NewResourceTFBuilder().
+			WithName("reissue_delete").
+			WithMethod("GET").
+			WithPath("/resource").
+			WithIsResponseBodyJSON(true).
+			WithResponseBodyIDFilter("$.id").
+			WithToleratedStatusCodes([]int{404}).
+			WithIsDeleteEnabled(true).
+			WithDeletePath("/resource/$.id").
+			Build()
+
+		// when / then
+		resource.UnitTest(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: create,
+					Check:  resource.TestCheckResourceAttr("http_request.reissue_delete", "response_body_id", "1"),
+				},
+				{
+					Config: enableDelete,
+					Check:  resource.TestCheckResourceAttr("http_request.reissue_delete", "response_body_id", "1"),
+				},
+			},
+		})
+
+		// then -- the test case auto-destroys at the end; the DELETE must have used the
+		// resolved path, proving the delete controls were refreshed from config.
+		if got := tracker.creates(); got != 1 {
+			t.Fatalf("expected exactly 1 outgoing create request (no re-issue), got %d", got)
+		}
+		if !tracker.deleted("/resource/1") {
+			t.Fatalf("expected a DELETE to /resource/1 after destroy, got %v", tracker.deletePaths)
+		}
+	})
+}

--- a/internal/provider/resource_http_request_reissue_test.go
+++ b/internal/provider/resource_http_request_reissue_test.go
@@ -1,0 +1,175 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rios0rios0/terraform-provider-http/internal/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func basicAuthAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"username": types.StringType,
+		"password": types.StringType,
+	}
+}
+
+// baselineReissueModel returns a fully-populated model used as the prior state in
+// the RequestAttributesChanged tests. Each test copies it and mutates a single
+// attribute, so the predicate is exercised one attribute at a time.
+func baselineReissueModel() provider.HTTPRequestResourceModel {
+	return provider.HTTPRequestResourceModel{
+		Method: types.StringValue("POST"),
+		Path:   types.StringValue("/things"),
+		Headers: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Content-Type": types.StringValue("application/json"),
+		}),
+		RequestBody: types.StringValue(`{"a":1}`),
+		QueryParameters: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"page": types.StringValue("1"),
+		}),
+		BaseURL:   types.StringValue("https://api.example.com"),
+		BasicAuth: types.ObjectNull(basicAuthAttrTypes()),
+		IgnoreTLS: types.BoolValue(false),
+
+		ToleratedStatusCodes: types.SetNull(types.Int32Type),
+		ResponseBodyIDFilter: types.StringValue("$.id"),
+		IsResponseBodyJSON:   types.BoolValue(true),
+		IgnoreChanges:        types.SetNull(types.StringType),
+
+		ID:                 types.StringValue("captured-id"),
+		ResponseCode:       types.Int32Value(200),
+		ResponseBody:       types.StringValue(`{"id":"1"}`),
+		ResponseBodyID:     types.StringValue("1"),
+		DeleteResolvedPath: types.StringNull(),
+	}
+}
+
+func TestRequestAttributesChanged(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should report no change when the plan equals the prior state", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		state := baselineReissueModel()
+		plan := baselineReissueModel()
+
+		// when
+		changed := provider.RequestAttributesChanged(plan, state)
+
+		// then
+		assert.False(t, changed, "identical models must not trigger a re-issue")
+	})
+
+	t.Run("should report a change when a request-defining attribute differs", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		state := baselineReissueModel()
+		mutations := map[string]func(m *provider.HTTPRequestResourceModel){
+			"method": func(m *provider.HTTPRequestResourceModel) {
+				m.Method = types.StringValue("PUT")
+			},
+			"path": func(m *provider.HTTPRequestResourceModel) {
+				m.Path = types.StringValue("/other")
+			},
+			"headers": func(m *provider.HTTPRequestResourceModel) {
+				m.Headers = types.MapValueMust(types.StringType, map[string]attr.Value{
+					"X-New": types.StringValue("y"),
+				})
+			},
+			"request_body": func(m *provider.HTTPRequestResourceModel) {
+				m.RequestBody = types.StringValue(`{"a":2}`)
+			},
+			"query_parameters": func(m *provider.HTTPRequestResourceModel) {
+				m.QueryParameters = types.MapValueMust(types.StringType, map[string]attr.Value{
+					"page": types.StringValue("2"),
+				})
+			},
+			"base_url": func(m *provider.HTTPRequestResourceModel) {
+				m.BaseURL = types.StringValue("https://api.other.com")
+			},
+			"basic_auth": func(m *provider.HTTPRequestResourceModel) {
+				m.BasicAuth = types.ObjectValueMust(basicAuthAttrTypes(), map[string]attr.Value{
+					"username": types.StringValue("u"),
+					"password": types.StringValue("p"),
+				})
+			},
+			"ignore_tls": func(m *provider.HTTPRequestResourceModel) {
+				m.IgnoreTLS = types.BoolValue(true)
+			},
+		}
+
+		for name, mutate := range mutations {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				// given
+				plan := baselineReissueModel()
+				mutate(&plan)
+
+				// when
+				changed := provider.RequestAttributesChanged(plan, state)
+
+				// then
+				assert.True(t, changed, "changing %s must trigger a re-issue", name)
+			})
+		}
+	})
+
+	t.Run("should report no change when only a client-side or computed attribute differs", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		state := baselineReissueModel()
+		mutations := map[string]func(m *provider.HTTPRequestResourceModel){
+			"tolerated_status_codes": func(m *provider.HTTPRequestResourceModel) {
+				m.ToleratedStatusCodes = types.SetValueMust(types.Int32Type, []attr.Value{
+					types.Int32Value(404),
+				})
+			},
+			"response_body_id_filter": func(m *provider.HTTPRequestResourceModel) {
+				m.ResponseBodyIDFilter = types.StringValue("$.data.id")
+			},
+			"is_response_body_json": func(m *provider.HTTPRequestResourceModel) {
+				m.IsResponseBodyJSON = types.BoolValue(false)
+			},
+			"ignore_changes": func(m *provider.HTTPRequestResourceModel) {
+				m.IgnoreChanges = types.SetValueMust(types.StringType, []attr.Value{
+					types.StringValue("headers"),
+				})
+			},
+			"id": func(m *provider.HTTPRequestResourceModel) {
+				m.ID = types.StringValue("different")
+			},
+			"response_body": func(m *provider.HTTPRequestResourceModel) {
+				m.ResponseBody = types.StringValue(`{"id":"2"}`)
+			},
+			"response_body_id": func(m *provider.HTTPRequestResourceModel) {
+				m.ResponseBodyID = types.StringValue("2")
+			},
+			"delete_resolved_path": func(m *provider.HTTPRequestResourceModel) {
+				m.DeleteResolvedPath = types.StringValue("/things/2")
+			},
+		}
+
+		for name, mutate := range mutations {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				// given
+				plan := baselineReissueModel()
+				mutate(&plan)
+
+				// when
+				changed := provider.RequestAttributesChanged(plan, state)
+
+				// then
+				assert.False(t, changed, "changing %s must NOT trigger a re-issue", name)
+			})
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`http_request` could fail an in-place update with `Error: Provider produced inconsistent result after apply` whenever the update changed only a **client-side** attribute — most commonly `tolerated_status_codes`.

## Root cause

`Update` calls `Create`, so it re-issues the HTTP request on **any** attribute change. The computed response attributes (`id`, `response_code`, `response_body`, `response_body_id`, `response_body_json`) use the `UseStateForUnknown` plan modifier, so the plan keeps their prior values. When the re-issued request returns a different response, the applied values no longer match the plan and Terraform aborts. Changing a client-side attribute (`tolerated_status_codes`) also repeats a non-idempotent request (e.g. a `POST`) for no reason.

## Fix

- `Update` re-issues the request **only** when an attribute that defines the request changed: `method`, `path`, `headers`, `request_body`, `query_parameters`, `base_url`, `basic_auth`, `ignore_tls`. A change limited to response-interpretation attributes (`tolerated_status_codes`, `response_body_id_filter`, `is_response_body_json`) or `ignore_changes` keeps the recorded response and makes no HTTP call.
- `ModifyPlan` marks the computed response attributes **unknown** when a request attribute changes, so a genuine re-issue's fresh response is accepted — this also fixes the same inconsistency for legitimate `request_body` / `headers` / `query_parameters` edits.

## Validation

With a local endpoint that returns a fresh id per request:

- **Released build:** adding `tolerated_status_codes` to an already-applied resource reproduces `inconsistent result after apply`.
- **Fixed build:** the same change applies cleanly and does **not** re-issue (the captured id is unchanged).
- **Control:** a real request change (adding a query parameter) still re-issues and is consistent.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
