### PR TITLE
chore(bump): bumped version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-06-18
+
 ### Added
 
 - added regression tests for the in-place update re-issue behavior: a unit test asserting that only request-defining attribute changes trigger a re-issue, and integration tests (driven by a local endpoint that returns a fresh id per request) proving that a client-side-only change neither re-issues the request nor fails apply, that a genuine request change still re-issues consistently, and that write-only destroy controls enabled in the same apply as a client-side-only change are still honored on destroy


### PR DESCRIPTION
## Summary

Releases the changes accumulated under `[Unreleased]` as **3.2.0**.

Highlights:
- **fix:** `http_request` no longer fails an in-place update with `Error: Provider produced inconsistent result after apply` when only a client-side attribute (e.g. `tolerated_status_codes`) changes — the request is re-issued only when a request-defining attribute actually changes.
- **fix:** `terraform destroy` now honors write-only delete controls changed in the same apply as a client-side-only update.
- **added:** regression tests (unit + integration) for the update re-issue behavior.

Minor bump because the `[Unreleased]` section carried an `### Added` entry (the new tests).

## :vertical_traffic_light: Quality checklist

- [x] `CHANGELOG.md` `[Unreleased]` moved to `## [3.2.0] - 2026-06-18`
- [x] Version is injected from the git tag at build time (`ldflags` + `git describe`) — no hardcoded version file to update
- [ ] On merge: tag `v3.2.0` → GoReleaser publishes to the Terraform Registry

---
*Bump generated by [AutoBump](https://github.com/rios0rios0/autobump); PR opened manually because the SSH host alias blocked autobump's own push.*
