### PR TITLE
feat(http): added request_timeout_ms and retry support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,7 @@ resource "http_request" "test_request" {
 - Delete operations with path resolution (`is_delete_enabled`, `delete_method`, `delete_path`, `delete_headers`, `delete_request_body`, `delete_resolved_path`). Since v3.0.0 these are WriteOnly attributes (not persisted in state; stored in provider private state)
 - `tolerated_status_codes` attribute to treat specific non-2xx HTTP status codes as successful
 - `ignore_changes` attribute to suppress diffs for specific resource attributes during updates
+- `request_timeout_ms` argument and a `retry` block (`attempts`, `min_delay_ms`, `max_delay_ms`) at both provider and resource level, mirroring the upstream `hashicorp/http` provider. The timeout bounds each attempt (0/unset = no timeout); retries cover connection errors and 5xx (except 501) with exponential backoff. Implemented in `getHTTPClient` via `github.com/hashicorp/go-retryablehttp`
 - Resource-level configuration (`base_url`, `basic_auth`, `ignore_tls`) to support `count`/`for_each` with different APIs
 - State importing via Base64-encoded JSON (`terraform import`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added a `request_timeout_ms` argument and a `retry` block (`attempts`, `min_delay_ms`, `max_delay_ms`) to both the provider and the `http_request` resource, mirroring the upstream `hashicorp/http` provider. Configured at the provider level they apply to every request; the matching resource-level arguments override them. `request_timeout_ms` bounds each individual attempt -- an unset or `0` value preserves the previous behavior of waiting indefinitely -- and retries are attempted on connection errors and on 5xx (except 501) responses using an exponential backoff bounded by `min_delay_ms` and `max_delay_ms`. This addresses requests hanging indefinitely against a slow or unreachable endpoint, since the underlying HTTP client previously set no timeout and performed no retries
+
 ### Changed
 
+- promoted `github.com/hashicorp/go-retryablehttp` to a direct dependency, used to implement the new request `retry` support
 - changed the Go module dependencies to their latest versions
 
 ## [3.2.2] - 2026-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - promoted `github.com/hashicorp/go-retryablehttp` to a direct dependency, used to implement the new request `retry` support
 - changed the Go module dependencies to their latest versions
 
+### Fixed
+
+- preserved connection-pool reuse when `ignore_tls` is enabled at the provider level: the request client now reuses the provider's existing `http.Transport` instead of allocating a fresh one per request, avoiding goroutine and file-descriptor churn across repeated requests
+
 ## [3.2.2] - 2026-06-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -54,6 +54,39 @@ output "response_body" {
 }
 ```
 
+### Timeouts and retries
+
+Both the provider and the `http_request` resource accept a `request_timeout_ms` argument and a
+`retry` block. Set on the provider they apply to every request; set on a resource they override
+the provider defaults. This prevents a request from hanging indefinitely against a slow or
+unreachable endpoint and transparently retries transient failures (connection errors and 5xx
+responses, except 501) using an exponential backoff:
+
+```hcl
+provider "http" {
+  url                = "https://api.example.com"
+  request_timeout_ms = 60000 # give up on any request that exceeds 60s
+
+  retry {
+    attempts     = 5     # up to 5 retries (6 attempts in total)
+    min_delay_ms = 1000  # optional, defaults to 1000
+    max_delay_ms = 30000 # optional, defaults to 30000
+  }
+}
+
+resource "http_request" "example" {
+  method = "POST"
+  path   = "/data"
+
+  # Override the provider defaults for this request only.
+  request_timeout_ms = 10000
+
+  retry {
+    attempts = 2
+  }
+}
+```
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ provider "http" {
 
 - `basic_auth` (Attributes) Credentials for basic authentication. This attribute allows you to specify the username and password required for basic HTTP authentication. It is optional and should be used when the target Web endpoint requires basic authentication for access. (see [below for nested schema](#nestedatt--basic_auth))
 - `ignore_tls` (Boolean) A boolean flag to indicate whether TLS certificate verification should be ignored. This is useful for testing purposes or when interacting with APIs that use self-signed certificates. It is optional and defaults to `false`.
+- `request_timeout_ms` (Number) The per-request timeout in milliseconds applied to every HTTP request made by this provider. When unset or `0`, no timeout is applied and a request can wait indefinitely. It can be overridden per resource using the `request_timeout_ms` argument.
+- `retry` (Block, Optional) Retry configuration applied to every HTTP request made by this provider. By default there are no retries. Retries are attempted on connection errors and on 5xx (except 501) responses. It can be overridden per resource using the `retry` block. (see [below for nested schema](#nestedblock--retry))
 - `url` (String) The base URL for all HTTP requests made by this provider. This URL serves as the root endpoint for the Web endpoint that the provider will interact with. This is optional when base_url is specified at the resource level.
 
 <a id="nestedatt--basic_auth"></a>
@@ -47,3 +49,13 @@ Required:
 
 - `password` (String, Sensitive) The password for basic authentication. This is a required field within the `basic_auth` block and must be provided if basic authentication is used. The password is marked as sensitive to ensure it is not exposed in logs or state files.
 - `username` (String) The username for basic authentication. This is a required field within the `basic_auth` block and must be provided if basic authentication is used.
+
+
+<a id="nestedblock--retry"></a>
+### Nested Schema for `retry`
+
+Optional:
+
+- `attempts` (Number) The maximum number of retries. For example, if `2` is specified, the request is tried a maximum of 3 times (the initial attempt plus 2 retries).
+- `max_delay_ms` (Number) The maximum delay between retries, in milliseconds. Defaults to `30000`.
+- `min_delay_ms` (Number) The minimum delay between retries, in milliseconds. Defaults to `1000`.

--- a/docs/resources/request.md
+++ b/docs/resources/request.md
@@ -242,7 +242,9 @@ resource "http_request" "idempotent_post" {
 - `is_response_body_json` (Boolean) A boolean flag indicating whether the response body is expected to be in JSON format.
 - `query_parameters` (Map of String) Optional query parameters to append to the request path
 - `request_body` (String) The body content to be sent with the HTTP request. This is typically used for POST and PUT requests.
+- `request_timeout_ms` (Number) The per-request timeout in milliseconds for this specific HTTP request. When specified, this overrides the provider-level request_timeout_ms. When unset or 0, no timeout is applied and a request can wait indefinitely.
 - `response_body_id_filter` (String) A JSONPath filter used to extract a specific ID from the JSON response body. This is useful for identifying unique elements within the response.
+- `retry` (Block, Optional) Retry configuration for this specific HTTP request. When specified, this overrides the provider-level retry configuration. By default there are no retries. (see [below for nested schema](#nestedblock--retry))
 - `tolerated_status_codes` (Set of Number) HTTP status codes that should be treated as successful in addition to the default 2xx range. For example, setting this to `[404]` allows the resource to succeed when the server returns a `404 Not Found`.
 
 ### Read-Only
@@ -261,6 +263,16 @@ Required:
 
 - `password` (String, Sensitive) The password for basic authentication.
 - `username` (String) The username for basic authentication.
+
+
+<a id="nestedblock--retry"></a>
+### Nested Schema for `retry`
+
+Optional:
+
+- `attempts` (Number) The maximum number of retries. For example, if `2` is specified, the request is tried a maximum of 3 times (the initial attempt plus 2 retries).
+- `max_delay_ms` (Number) The maximum delay between retries, in milliseconds. Defaults to `30000`.
+- `min_delay_ms` (Number) The minimum delay between retries, in milliseconds. Defaults to `1000`.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
@@ -38,7 +39,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.8.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.5 // indirect

--- a/internal/domain/entities/configuration.go
+++ b/internal/domain/entities/configuration.go
@@ -3,11 +3,29 @@ package entities
 type Configuration struct {
 	URL       string
 	BasicAuth *BasicAuth
+	// RequestTimeoutMs is the per-request timeout in milliseconds applied to the
+	// underlying HTTP client. A value of 0 means no timeout (the client waits
+	// indefinitely, which is the Go default).
+	RequestTimeoutMs int64
+	// Retry holds the retry configuration. A nil value means no retries.
+	Retry *RetryConfig
 }
 
 type BasicAuth struct {
 	Username string
 	Password string
+}
+
+// RetryConfig describes how a failed HTTP request should be retried. It mirrors
+// the semantics of the upstream hashicorp/http provider's `retry` block.
+type RetryConfig struct {
+	// Attempts is the maximum number of retries. For example, if 2 is specified,
+	// the request is tried a maximum of 3 times (the initial attempt plus 2 retries).
+	Attempts int64
+	// MinDelayMs is the minimum delay between retries, in milliseconds.
+	MinDelayMs int64
+	// MaxDelayMs is the maximum delay between retries, in milliseconds.
+	MaxDelayMs int64
 }
 
 func NewConfiguration(url string) *Configuration {

--- a/internal/infrastructure/helpers/resource_helper.go
+++ b/internal/infrastructure/helpers/resource_helper.go
@@ -105,6 +105,22 @@ func BoolAttributeNoReplace(required bool, description string) schema.BoolAttrib
 	return attribute
 }
 
+// Int64AttributeNoReplace creates an optional/required int64 attribute that does NOT trigger
+// replacement on change. Use this for operational tuning knobs (timeout, retry) that only
+// affect how a request is transported, not the request that is sent.
+func Int64AttributeNoReplace(required bool, description string) schema.Int64Attribute {
+	attribute := schema.Int64Attribute{
+		Description:         description,
+		MarkdownDescription: description,
+	}
+	if required {
+		attribute.Required = true
+	} else {
+		attribute.Optional = true
+	}
+	return attribute
+}
+
 func StringAttributeWriteOnly(required bool, description string) schema.StringAttribute {
 	attribute := schema.StringAttribute{
 		Description:         description,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,10 +16,28 @@ import (
 )
 
 const (
-	attrBasicAuth = "basic_auth"
-	attrIgnoreTLS = "ignore_tls"
-	attrUsername  = "username"
-	attrPassword  = "password"
+	attrBasicAuth        = "basic_auth"
+	attrIgnoreTLS        = "ignore_tls"
+	attrUsername         = "username"
+	attrPassword         = "password"
+	attrRequestTimeoutMs = "request_timeout_ms"
+	attrRetry            = "retry"
+	attrAttempts         = "attempts"
+	attrMinDelayMs       = "min_delay_ms"
+	attrMaxDelayMs       = "max_delay_ms"
+)
+
+// Descriptions for the retry/timeout knobs. They are shared between the provider
+// and the resource schema builders (same package) so the wording lives in one
+// place and the two schemas cannot drift apart.
+const (
+	descRetryAttempts = "The maximum number of retries. For example, if `2` is specified, the request is " +
+		"tried a maximum of 3 times (the initial attempt plus 2 retries)."
+	descRetryMinDelayMs          = "The minimum delay between retries, in milliseconds. Defaults to `1000`."
+	descRetryMaxDelayMs          = "The maximum delay between retries, in milliseconds. Defaults to `30000`."
+	descRequestTimeoutMsProvider = "The per-request timeout in milliseconds applied to every HTTP request " +
+		"made by this provider. When unset or `0`, no timeout is applied and a request can wait indefinitely. " +
+		"It can be overridden per resource using the `request_timeout_ms` argument."
 )
 
 // Ensure HTTPProvider satisfies various provider interfaces.
@@ -35,9 +53,11 @@ type HTTPProvider struct {
 
 // HTTPProviderModel describes the provider data model.
 type HTTPProviderModel struct {
-	URL       types.String `tfsdk:"url"        json:"url"`
-	BasicAuth types.Object `tfsdk:"basic_auth" json:"basic_auth"`
-	IgnoreTLS types.Bool   `tfsdk:"ignore_tls" json:"-"`
+	URL              types.String `tfsdk:"url"                json:"url"`
+	BasicAuth        types.Object `tfsdk:"basic_auth"         json:"basic_auth"`
+	IgnoreTLS        types.Bool   `tfsdk:"ignore_tls"         json:"-"`
+	RequestTimeoutMs types.Int64  `tfsdk:"request_timeout_ms" json:"-"`
+	Retry            types.Object `tfsdk:"retry"              json:"-"`
 }
 
 func New(version string) func() provider.Provider {
@@ -102,6 +122,40 @@ func GetHTTPProviderSchema() schema.Schema {
 					"It is optional and defaults to `false`.",
 				Optional: true,
 			},
+			attrRequestTimeoutMs: providerOptionalInt64(descRequestTimeoutMsProvider),
+		},
+		Blocks: map[string]schema.Block{
+			attrRetry: retryBlock(),
+		},
+	}
+}
+
+// providerOptionalInt64 builds an optional provider-level Int64 attribute,
+// keeping `Description` and `MarkdownDescription` in sync.
+func providerOptionalInt64(description string) schema.Int64Attribute {
+	return schema.Int64Attribute{
+		Description:         description,
+		MarkdownDescription: description,
+		Optional:            true,
+	}
+}
+
+// retryBlock returns the provider-level `retry` block. It mirrors the upstream
+// hashicorp/http provider's retry semantics: retries are attempted on connection
+// errors and on 5xx (except 501) responses, with an exponential backoff bounded
+// by `min_delay_ms` and `max_delay_ms`. Configured here it applies to every
+// request; it can be overridden per resource.
+func retryBlock() schema.SingleNestedBlock {
+	description := "Retry configuration applied to every HTTP request made by this provider. " +
+		"By default there are no retries. Retries are attempted on connection errors and on 5xx " +
+		"(except 501) responses. It can be overridden per resource using the `retry` block."
+	return schema.SingleNestedBlock{
+		Description:         description,
+		MarkdownDescription: description,
+		Attributes: map[string]schema.Attribute{
+			attrAttempts:   providerOptionalInt64(descRetryAttempts),
+			attrMinDelayMs: providerOptionalInt64(descRetryMinDelayMs),
+			attrMaxDelayMs: providerOptionalInt64(descRetryMaxDelayMs),
 		},
 	}
 }
@@ -219,6 +273,10 @@ func (it *HTTPProvider) Configure(
 			Password: password,
 		}
 	}
+	if !model.RequestTimeoutMs.IsNull() && !model.RequestTimeoutMs.IsUnknown() {
+		internal.Config.RequestTimeoutMs = model.RequestTimeoutMs.ValueInt64()
+	}
+	internal.Config.Retry = retryConfigFromObject(model.Retry)
 
 	resp.ResourceData = internal
 	resp.DataSourceData = internal

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -38,6 +38,32 @@ func testAccPreCheck(_ *testing.T) {
 	// function.
 }
 
+// fullProviderType returns the complete provider object type used by the
+// ValidateConfig tests, keeping the (otherwise duplicated) builder chain in one place.
+func fullProviderType() tftypes.Object {
+	return builders.NewProviderTypeBuilder().
+		WithURL().
+		WithIgnoreTLS().
+		WithUsername().
+		WithPassword().
+		WithRequestTimeoutMs().
+		WithRetry().
+		Build()
+}
+
+// nullRetryValue returns a null `retry` nested-block value matching the schema,
+// used to satisfy the full provider object type in ValidateConfig tests.
+func nullRetryValue() tftypes.Value {
+	return tftypes.NewValue(
+		tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"attempts":     tftypes.Number,
+			"min_delay_ms": tftypes.Number,
+			"max_delay_ms": tftypes.Number,
+		}},
+		nil,
+	)
+}
+
 func TestHTTPProvider(t *testing.T) {
 	t.Parallel()
 
@@ -113,12 +139,7 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 		req := provider.ValidateConfigRequest{
 			Config: tfsdk.Config{
 				Raw: tftypes.NewValue(
-					builders.NewProviderTypeBuilder().
-						WithURL().
-						WithIgnoreTLS().
-						WithUsername().
-						WithPassword().
-						Build(),
+					fullProviderType(),
 					map[string]tftypes.Value{
 						"url": tftypes.NewValue(tftypes.String, "https://jsonplaceholder.typicode.com"),
 						"basic_auth": tftypes.NewValue(
@@ -130,7 +151,9 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 							},
 							nil,
 						),
-						"ignore_tls": tftypes.NewValue(tftypes.Bool, nil),
+						"ignore_tls":         tftypes.NewValue(tftypes.Bool, nil),
+						"request_timeout_ms": tftypes.NewValue(tftypes.Number, nil),
+						"retry":              nullRetryValue(),
 					},
 				),
 				Schema: GetHTTPProviderSchema(),
@@ -154,12 +177,7 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 		req := provider.ValidateConfigRequest{
 			Config: tfsdk.Config{
 				Raw: tftypes.NewValue(
-					builders.NewProviderTypeBuilder().
-						WithURL().
-						WithIgnoreTLS().
-						WithUsername().
-						WithPassword().
-						Build(),
+					fullProviderType(),
 					map[string]tftypes.Value{
 						"url": tftypes.NewValue(tftypes.String, nil),
 						"basic_auth": tftypes.NewValue(
@@ -171,7 +189,9 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 							},
 							nil,
 						),
-						"ignore_tls": tftypes.NewValue(tftypes.Bool, nil),
+						"ignore_tls":         tftypes.NewValue(tftypes.Bool, nil),
+						"request_timeout_ms": tftypes.NewValue(tftypes.Number, nil),
+						"retry":              nullRetryValue(),
 					},
 				),
 				Schema: GetHTTPProviderSchema(),
@@ -225,12 +245,7 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 		req := provider.ValidateConfigRequest{
 			Config: tfsdk.Config{
 				Raw: tftypes.NewValue(
-					builders.NewProviderTypeBuilder().
-						WithURL().
-						WithIgnoreTLS().
-						WithUsername().
-						WithPassword().
-						Build(),
+					fullProviderType(),
 					map[string]tftypes.Value{
 						"url": tftypes.NewValue(tftypes.String, "https://jsonplaceholder.typicode.com"),
 						"basic_auth": tftypes.NewValue(
@@ -245,7 +260,9 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 								"password": tftypes.NewValue(tftypes.String, "pass"),
 							},
 						),
-						"ignore_tls": tftypes.NewValue(tftypes.Bool, nil),
+						"ignore_tls":         tftypes.NewValue(tftypes.Bool, nil),
+						"request_timeout_ms": tftypes.NewValue(tftypes.Number, nil),
+						"retry":              nullRetryValue(),
 					},
 				),
 				Schema: GetHTTPProviderSchema(),
@@ -269,12 +286,7 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 		req := provider.ValidateConfigRequest{
 			Config: tfsdk.Config{
 				Raw: tftypes.NewValue(
-					builders.NewProviderTypeBuilder().
-						WithURL().
-						WithIgnoreTLS().
-						WithUsername().
-						WithPassword().
-						Build(),
+					fullProviderType(),
 					map[string]tftypes.Value{
 						"url": tftypes.NewValue(tftypes.String, "https://jsonplaceholder.typicode.com"),
 						"basic_auth": tftypes.NewValue(
@@ -289,7 +301,9 @@ func TestHTTPProvider_ValidateConfig(t *testing.T) {
 								"password": tftypes.NewValue(tftypes.String, nil),
 							},
 						),
-						"ignore_tls": tftypes.NewValue(tftypes.Bool, nil),
+						"ignore_tls":         tftypes.NewValue(tftypes.Bool, nil),
+						"request_timeout_ms": tftypes.NewValue(tftypes.Number, nil),
+						"retry":              nullRetryValue(),
 					},
 				),
 				Schema: GetHTTPProviderSchema(),

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -1701,15 +1701,7 @@ func (it *HTTPRequestResource) getHTTPClient(
 
 	base := &http.Client{Timeout: timeout}
 	if ignoreTLS {
-		base.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion: tls.VersionTLS13,
-				// InsecureSkipVerify is intentionally set to true when ignore_tls is enabled.
-				// This is a user-controlled feature for testing and self-signed certificates.
-				//nolint:gosec // purposefully ignore TLS verification according to user configuration
-				InsecureSkipVerify: true,
-			},
-		}
+		base.Transport = it.resolveInsecureTransport()
 	}
 
 	if retryCfg == nil || retryCfg.Attempts <= 0 {
@@ -1739,6 +1731,29 @@ func (it *HTTPRequestResource) resolveIgnoreTLS(model HTTPRequestResourceModel) 
 		}
 	}
 	return false
+}
+
+// resolveInsecureTransport returns a transport that skips TLS verification. It
+// reuses the provider-level transport when one is already configured so the
+// underlying connection pool is shared across requests; a fresh transport is
+// allocated only when there is none to reuse (for example, a resource-level
+// ignore_tls override turning verification off where the provider left it on).
+func (it *HTTPRequestResource) resolveInsecureTransport() http.RoundTripper {
+	if it.internal != nil && it.internal.Client != nil {
+		if transport, ok := it.internal.Client.Transport.(*http.Transport); ok &&
+			transport.TLSClientConfig != nil && transport.TLSClientConfig.InsecureSkipVerify {
+			return transport
+		}
+	}
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			// InsecureSkipVerify is intentionally set to true when ignore_tls is enabled.
+			// This is a user-controlled feature for testing and self-signed certificates.
+			//nolint:gosec // purposefully ignore TLS verification according to user configuration
+			InsecureSkipVerify: true,
+		},
+	}
 }
 
 // resolveTimeout resolves the effective per-request timeout: a resource-level

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -16,8 +16,10 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -73,9 +75,11 @@ type HTTPRequestResourceModel struct {
 	IgnoreChanges        types.Set    `tfsdk:"ignore_changes"`
 
 	// resource-level configuration (alternative to provider-level)
-	BaseURL   types.String `tfsdk:"base_url"`
-	BasicAuth types.Object `tfsdk:"basic_auth"`
-	IgnoreTLS types.Bool   `tfsdk:"ignore_tls"`
+	BaseURL          types.String `tfsdk:"base_url"`
+	BasicAuth        types.Object `tfsdk:"basic_auth"`
+	IgnoreTLS        types.Bool   `tfsdk:"ignore_tls"`
+	RequestTimeoutMs types.Int64  `tfsdk:"request_timeout_ms"`
+	Retry            types.Object `tfsdk:"retry"`
 
 	// destroy controls
 	IsDeleteEnabled    types.Bool   `tfsdk:"is_delete_enabled"`
@@ -107,9 +111,11 @@ type HTTPRequestResourceModelNative struct {
 	IgnoreChanges        []string          `json:"ignore_changes,omitempty"`
 
 	// resource-level configuration (alternative to provider-level)
-	BaseURL   string            `json:"base_url,omitempty"`
-	BasicAuth map[string]string `json:"basic_auth,omitempty"`
-	IgnoreTLS bool              `json:"ignore_tls,omitempty"`
+	BaseURL          string            `json:"base_url,omitempty"`
+	BasicAuth        map[string]string `json:"basic_auth,omitempty"`
+	IgnoreTLS        bool              `json:"ignore_tls,omitempty"`
+	RequestTimeoutMs *int64            `json:"request_timeout_ms,omitempty"`
+	Retry            *retryNative      `json:"retry,omitempty"`
 
 	// destroy controls
 	IsDeleteEnabled   bool              `json:"is_delete_enabled,omitempty"`
@@ -125,6 +131,89 @@ type HTTPRequestResourceModelNative struct {
 	ResponseBodyJSON map[string]string `json:"response_body_json,omitempty"`
 }
 
+// retryNative is the native (JSON) representation of the `retry` block, used by
+// the Base64 import payload.
+type retryNative struct {
+	Attempts   *int64 `json:"attempts,omitempty"`
+	MinDelayMs *int64 `json:"min_delay_ms,omitempty"`
+	MaxDelayMs *int64 `json:"max_delay_ms,omitempty"`
+}
+
+// Default retry delays, matching the upstream hashicorp/http provider behavior.
+const (
+	defaultRetryMinDelayMs int64 = 1000
+	defaultRetryMaxDelayMs int64 = 30000
+)
+
+// retryObjectAttrTypes returns the attribute types of the `retry` nested object.
+// It MUST be used wherever a typed null `retry` value is produced, otherwise the
+// framework raises a "missing type" conversion error.
+func retryObjectAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		attrAttempts:   types.Int64Type,
+		attrMinDelayMs: types.Int64Type,
+		attrMaxDelayMs: types.Int64Type,
+	}
+}
+
+// retryConfigFromObject converts a `retry` nested object into the domain
+// RetryConfig, applying the default delays for any unset sub-attribute. It
+// returns nil when the object is null/unknown (meaning "no retries").
+func retryConfigFromObject(obj types.Object) *entities.RetryConfig {
+	if obj.IsNull() || obj.IsUnknown() {
+		return nil
+	}
+
+	cfg := &entities.RetryConfig{
+		MinDelayMs: defaultRetryMinDelayMs,
+		MaxDelayMs: defaultRetryMaxDelayMs,
+	}
+	attrs := obj.Attributes()
+	if v, ok := attrs[attrAttempts].(types.Int64); ok && !v.IsNull() && !v.IsUnknown() {
+		cfg.Attempts = v.ValueInt64()
+	}
+	if v, ok := attrs[attrMinDelayMs].(types.Int64); ok && !v.IsNull() && !v.IsUnknown() {
+		cfg.MinDelayMs = v.ValueInt64()
+	}
+	if v, ok := attrs[attrMaxDelayMs].(types.Int64); ok && !v.IsNull() && !v.IsUnknown() {
+		cfg.MaxDelayMs = v.ValueInt64()
+	}
+
+	// Defensive clamping: keep delays sane regardless of user input.
+	if cfg.MinDelayMs < 0 {
+		cfg.MinDelayMs = 0
+	}
+	if cfg.MaxDelayMs < cfg.MinDelayMs {
+		cfg.MaxDelayMs = cfg.MinDelayMs
+	}
+	return cfg
+}
+
+func int64PtrToValue(p *int64) types.Int64 {
+	if p == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(*p)
+}
+
+// retryObjectFromNative reconstructs a typed `retry` object from the native
+// import payload, returning a typed null when no retry data is present.
+func retryObjectFromNative(rn *retryNative, diagnostics *diag.Diagnostics) types.Object {
+	if rn == nil {
+		return types.ObjectNull(retryObjectAttrTypes())
+	}
+	obj, diags := types.ObjectValue(retryObjectAttrTypes(), map[string]attr.Value{
+		attrAttempts:   int64PtrToValue(rn.Attempts),
+		attrMinDelayMs: int64PtrToValue(rn.MinDelayMs),
+		attrMaxDelayMs: int64PtrToValue(rn.MaxDelayMs),
+	})
+	if diags.HasError() {
+		diagnostics.Append(diags...)
+		return types.ObjectNull(retryObjectAttrTypes())
+	}
+	return obj
+}
+
 func NewHTTPRequestResource() resource.Resource {
 	return &HTTPRequestResource{}
 }
@@ -133,6 +222,7 @@ func GetHTTPRequestResourceSchema() schema.Schema {
 	attrs := make(map[string]schema.Attribute)
 	addRequestAttributes(attrs)
 	addResourceConfigAttributes(attrs)
+	addRetryTimeoutAttributes(attrs)
 	addDeleteControlAttributes(attrs)
 	addStateAttributes(attrs)
 
@@ -143,6 +233,37 @@ func GetHTTPRequestResourceSchema() schema.Schema {
 		MarkdownDescription: "Represents an HTTP request resource, allowing configuration of various " +
 			"HTTP request parameters and capturing the response details.",
 		Attributes: attrs,
+		Blocks: map[string]schema.Block{
+			attrRetry: resourceRetryBlock(),
+		},
+	}
+}
+
+// addRetryTimeoutAttributes adds the operational `request_timeout_ms` knob. It is
+// intentionally NOT part of addResourceConfigAttributes so the v0 upgrade schema
+// (which reuses that function) keeps its pre-existing shape.
+func addRetryTimeoutAttributes(attrs map[string]schema.Attribute) {
+	attrs[attrRequestTimeoutMs] = helpers.Int64AttributeNoReplace(false,
+		"The per-request timeout in milliseconds for this specific HTTP request. When specified, "+
+			"this overrides the provider-level request_timeout_ms. When unset or 0, no timeout is applied "+
+			"and a request can wait indefinitely.")
+}
+
+// resourceRetryBlock returns the resource-level `retry` block. When set it
+// overrides the provider-level retry configuration. Retries are attempted on
+// connection errors and on 5xx (except 501) responses, with an exponential
+// backoff bounded by min_delay_ms and max_delay_ms.
+func resourceRetryBlock() schema.SingleNestedBlock {
+	description := "Retry configuration for this specific HTTP request. When specified, this overrides " +
+		"the provider-level retry configuration. By default there are no retries."
+	return schema.SingleNestedBlock{
+		Description:         description,
+		MarkdownDescription: description,
+		Attributes: map[string]schema.Attribute{
+			attrAttempts:   helpers.Int64AttributeNoReplace(false, descRetryAttempts),
+			attrMinDelayMs: helpers.Int64AttributeNoReplace(false, descRetryMinDelayMs),
+			attrMaxDelayMs: helpers.Int64AttributeNoReplace(false, descRetryMaxDelayMs),
+		},
 	}
 }
 
@@ -852,11 +973,17 @@ func (it *HTTPRequestResource) UpgradeState(_ context.Context) map[int64]resourc
 					BasicAuth:            oldModel.BasicAuth,
 					IgnoreTLS:            oldModel.IgnoreTLS,
 					DeleteResolvedPath:   oldModel.DeleteResolvedPath,
-					ID:                   oldModel.ID,
-					ResponseCode:         oldModel.ResponseCode,
-					ResponseBody:         oldModel.ResponseBody,
-					ResponseBodyID:       oldModel.ResponseBodyID,
-					ResponseBodyJSON:     oldModel.ResponseBodyJSON,
+
+					// request_timeout_ms and retry are new in this schema version; carry them as
+					// typed nulls so the very next plan does not fail with a "missing type"
+					// conversion error (mirrors the delete_* WriteOnly fix in 3.1.10).
+					RequestTimeoutMs: types.Int64Null(),
+					Retry:            types.ObjectNull(retryObjectAttrTypes()),
+					ID:               oldModel.ID,
+					ResponseCode:     oldModel.ResponseCode,
+					ResponseBody:     oldModel.ResponseBody,
+					ResponseBodyID:   oldModel.ResponseBodyID,
+					ResponseBodyJSON: oldModel.ResponseBodyJSON,
 
 					// The delete-control attributes became WriteOnly in schema v1. They must be
 					// carried as TYPED nulls here -- leaving them as the struct's zero value gives
@@ -1359,6 +1486,11 @@ func setResourceLevelFields(
 		model.IgnoreTLS = types.BoolValue(nativeModel.IgnoreTLS)
 	}
 
+	// Operational tuning knobs (optional). retry must always be a typed object so
+	// the imported state is plannable; a typed null is used when absent.
+	model.RequestTimeoutMs = int64PtrToValue(nativeModel.RequestTimeoutMs)
+	model.Retry = retryObjectFromNative(nativeModel.Retry, diagnostics)
+
 	// Handle BasicAuth object - must always be initialized with correct type
 	setBasicAuthField(model, nativeModel, diagnostics)
 }
@@ -1551,52 +1683,89 @@ func (it *HTTPRequestResource) buildFullURL(
 	return finalURL, diags
 }
 
-// getHTTPClient returns the HTTP client to use for this request,
-// taking into account resource-level TLS configuration.
+// getHTTPClient returns the HTTP client to use for this request. It resolves the
+// effective TLS, timeout, and retry settings -- resource-level values take
+// precedence over the provider-level configuration -- and builds a client
+// accordingly. When retries are configured the returned client transparently
+// retries on connection errors and 5xx (except 501) responses, applying an
+// exponential backoff bounded by the configured min/max delays. The per-request
+// timeout (when set) bounds each individual attempt; an unset/zero timeout
+// preserves the historical behavior of waiting indefinitely.
 func (it *HTTPRequestResource) getHTTPClient(
 	_ context.Context,
 	model HTTPRequestResourceModel,
 ) *http.Client {
-	// Check if resource-level ignore_tls setting should override provider-level
-	var ignoreTLS bool
-	switch {
-	case !model.IgnoreTLS.IsNull():
-		ignoreTLS = model.IgnoreTLS.ValueBool()
-	case it.internal.Client.Transport != nil:
-		// Fall back to provider-level setting (default is false if not set)
-		if transport, ok := it.internal.Client.Transport.(*http.Transport); ok && transport.TLSClientConfig != nil {
-			ignoreTLS = transport.TLSClientConfig.InsecureSkipVerify
-		}
-	}
+	ignoreTLS := it.resolveIgnoreTLS(model)
+	timeout := it.resolveTimeout(model)
+	retryCfg := it.resolveRetry(model)
 
-	// If resource-level setting matches what's already configured, reuse the client
-	currentIgnoreTLS := false
-	if it.internal.Client.Transport != nil {
-		if transport, ok := it.internal.Client.Transport.(*http.Transport); ok {
-			if transport.TLSClientConfig != nil {
-				currentIgnoreTLS = transport.TLSClientConfig.InsecureSkipVerify
-			}
-		}
-	}
-
-	if ignoreTLS == currentIgnoreTLS {
-		return it.internal.Client
-	}
-
-	// Create a new client with the desired TLS configuration
-	client := &http.Client{}
+	base := &http.Client{Timeout: timeout}
 	if ignoreTLS {
-		transport := &http.Transport{
+		base.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				MinVersion: tls.VersionTLS13,
-				// InsecureSkipVerify is intentionally set to true when ignore_tls is enabled
-				// This is a user-controlled feature for testing and self-signed certificates
+				// InsecureSkipVerify is intentionally set to true when ignore_tls is enabled.
+				// This is a user-controlled feature for testing and self-signed certificates.
 				//nolint:gosec // purposefully ignore TLS verification according to user configuration
 				InsecureSkipVerify: true,
 			},
 		}
-		client.Transport = transport
 	}
 
-	return client
+	if retryCfg == nil || retryCfg.Attempts <= 0 {
+		return base
+	}
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.HTTPClient = base
+	// Silence the library's default stderr logger; diagnostics flow through tflog.
+	retryClient.Logger = nil
+	retryClient.RetryMax = int(retryCfg.Attempts)
+	retryClient.RetryWaitMin = time.Duration(retryCfg.MinDelayMs) * time.Millisecond
+	retryClient.RetryWaitMax = time.Duration(retryCfg.MaxDelayMs) * time.Millisecond
+	return retryClient.StandardClient()
+}
+
+// resolveIgnoreTLS resolves the effective ignore_tls setting: a resource-level
+// value wins; otherwise the provider-level value (detected from the configured
+// client transport) is used.
+func (it *HTTPRequestResource) resolveIgnoreTLS(model HTTPRequestResourceModel) bool {
+	if !model.IgnoreTLS.IsNull() {
+		return model.IgnoreTLS.ValueBool()
+	}
+	if it.internal != nil && it.internal.Client != nil && it.internal.Client.Transport != nil {
+		if transport, ok := it.internal.Client.Transport.(*http.Transport); ok && transport.TLSClientConfig != nil {
+			return transport.TLSClientConfig.InsecureSkipVerify
+		}
+	}
+	return false
+}
+
+// resolveTimeout resolves the effective per-request timeout: a resource-level
+// value wins; otherwise the provider-level value is used. A non-positive value
+// means no timeout.
+func (it *HTTPRequestResource) resolveTimeout(model HTTPRequestResourceModel) time.Duration {
+	var ms int64
+	if it.internal != nil && it.internal.Config != nil {
+		ms = it.internal.Config.RequestTimeoutMs
+	}
+	if !model.RequestTimeoutMs.IsNull() && !model.RequestTimeoutMs.IsUnknown() {
+		ms = model.RequestTimeoutMs.ValueInt64()
+	}
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// resolveRetry resolves the effective retry configuration: a resource-level
+// `retry` block wins; otherwise the provider-level configuration is used.
+func (it *HTTPRequestResource) resolveRetry(model HTTPRequestResourceModel) *entities.RetryConfig {
+	if !model.Retry.IsNull() && !model.Retry.IsUnknown() {
+		return retryConfigFromObject(model.Retry)
+	}
+	if it.internal != nil && it.internal.Config != nil {
+		return it.internal.Config.Retry
+	}
+	return nil
 }

--- a/internal/provider/resource_http_request_reissue_test.go
+++ b/internal/provider/resource_http_request_reissue_test.go
@@ -16,6 +16,14 @@ func basicAuthAttrTypes() map[string]attr.Type {
 	}
 }
 
+func retryAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"attempts":     types.Int64Type,
+		"min_delay_ms": types.Int64Type,
+		"max_delay_ms": types.Int64Type,
+	}
+}
+
 // baselineReissueModel returns a fully-populated model used as the prior state in
 // the RequestAttributesChanged tests. Each test copies it and mutates a single
 // attribute, so the predicate is exercised one attribute at a time.
@@ -153,6 +161,16 @@ func TestRequestAttributesChanged(t *testing.T) {
 			},
 			"delete_resolved_path": func(m *provider.HTTPRequestResourceModel) {
 				m.DeleteResolvedPath = types.StringValue("/things/2")
+			},
+			"request_timeout_ms": func(m *provider.HTTPRequestResourceModel) {
+				m.RequestTimeoutMs = types.Int64Value(60000)
+			},
+			"retry": func(m *provider.HTTPRequestResourceModel) {
+				m.Retry = types.ObjectValueMust(retryAttrTypes(), map[string]attr.Value{
+					"attempts":     types.Int64Value(5),
+					"min_delay_ms": types.Int64Null(),
+					"max_delay_ms": types.Int64Null(),
+				})
 			},
 		}
 

--- a/internal/provider/resource_http_request_retry_test.go
+++ b/internal/provider/resource_http_request_retry_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rios0rios0/terraform-provider-http/internal/domain/entities"
 )
 
 func retryObject(attempts, minDelayMs, maxDelayMs types.Int64) types.Object {
@@ -208,5 +210,54 @@ func TestGetHTTPClientTimeout(t *testing.T) {
 		// then
 		assert.Equal(t, time.Duration(0), client.Timeout,
 			"an unset timeout preserves the historical no-timeout behavior")
+	})
+}
+
+func TestGetHTTPClientTransportReuse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should reuse the provider transport when ignore_tls is set at the provider level", func(t *testing.T) {
+		t.Parallel()
+
+		// given: a provider configured with ignore_tls owns an insecure transport
+		internal := entities.NewInternalContext(true, entities.NewConfiguration(""))
+		providerTransport := internal.Client.Transport
+		require.NotNil(t, providerTransport, "the provider should own a transport when ignore_tls is enabled")
+		it := &HTTPRequestResource{internal: internal}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolNull(),
+			RequestTimeoutMs: types.Int64Null(),
+			Retry:            types.ObjectNull(retryObjectAttrTypes()),
+		}
+
+		// when
+		client := it.getHTTPClient(context.Background(), model)
+
+		// then
+		assert.Same(t, providerTransport, client.Transport,
+			"the provider transport must be reused so the connection pool is shared across requests")
+	})
+
+	t.Run("should allocate a fresh transport when a resource overrides ignore_tls from false to true", func(t *testing.T) {
+		t.Parallel()
+
+		// given: a provider that verifies TLS has no insecure transport to reuse
+		internal := entities.NewInternalContext(false, entities.NewConfiguration(""))
+		it := &HTTPRequestResource{internal: internal}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolValue(true),
+			RequestTimeoutMs: types.Int64Null(),
+			Retry:            types.ObjectNull(retryObjectAttrTypes()),
+		}
+
+		// when
+		client := it.getHTTPClient(context.Background(), model)
+
+		// then
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok, "a fresh *http.Transport must be created for the resource-level override")
+		require.NotNil(t, transport.TLSClientConfig)
+		assert.True(t, transport.TLSClientConfig.InsecureSkipVerify,
+			"the new transport must skip verification per the resource override")
 	})
 }

--- a/internal/provider/resource_http_request_retry_test.go
+++ b/internal/provider/resource_http_request_retry_test.go
@@ -1,0 +1,212 @@
+//go:build unit || integration
+
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func retryObject(attempts, minDelayMs, maxDelayMs types.Int64) types.Object {
+	return types.ObjectValueMust(retryObjectAttrTypes(), map[string]attr.Value{
+		attrAttempts:   attempts,
+		attrMinDelayMs: minDelayMs,
+		attrMaxDelayMs: maxDelayMs,
+	})
+}
+
+func TestRetryConfigFromObject(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should return nil when the object is null", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		obj := types.ObjectNull(retryObjectAttrTypes())
+
+		// when
+		cfg := retryConfigFromObject(obj)
+
+		// then
+		assert.Nil(t, cfg, "a null retry block means no retries")
+	})
+
+	t.Run("should apply default delays when only attempts is set", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		obj := retryObject(types.Int64Value(5), types.Int64Null(), types.Int64Null())
+
+		// when
+		cfg := retryConfigFromObject(obj)
+
+		// then
+		require.NotNil(t, cfg)
+		assert.Equal(t, int64(5), cfg.Attempts, "attempts is taken from the block")
+		assert.Equal(t, defaultRetryMinDelayMs, cfg.MinDelayMs, "min delay defaults to 1000ms")
+		assert.Equal(t, defaultRetryMaxDelayMs, cfg.MaxDelayMs, "max delay defaults to 30000ms")
+	})
+
+	t.Run("should honor explicit delays", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		obj := retryObject(types.Int64Value(3), types.Int64Value(250), types.Int64Value(2000))
+
+		// when
+		cfg := retryConfigFromObject(obj)
+
+		// then
+		require.NotNil(t, cfg)
+		assert.Equal(t, int64(3), cfg.Attempts)
+		assert.Equal(t, int64(250), cfg.MinDelayMs)
+		assert.Equal(t, int64(2000), cfg.MaxDelayMs)
+	})
+
+	t.Run("should clamp a max delay that is below the min delay", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		obj := retryObject(types.Int64Value(2), types.Int64Value(5000), types.Int64Value(1000))
+
+		// when
+		cfg := retryConfigFromObject(obj)
+
+		// then
+		require.NotNil(t, cfg)
+		assert.Equal(t, int64(5000), cfg.MinDelayMs)
+		assert.Equal(t, int64(5000), cfg.MaxDelayMs, "max is raised to min when configured lower")
+	})
+}
+
+func TestGetHTTPClientRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should retry on 5xx and eventually succeed", func(t *testing.T) {
+		t.Parallel()
+
+		// given: the endpoint fails twice with 503 before returning 200
+		var calls atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer server.Close()
+
+		it := &HTTPRequestResource{}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolNull(),
+			RequestTimeoutMs: types.Int64Null(),
+			Retry:            retryObject(types.Int64Value(5), types.Int64Value(1), types.Int64Value(2)),
+		}
+		client := it.getHTTPClient(context.Background(), model)
+
+		// when
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+
+		// then
+		require.NoError(t, err, "the request should succeed after the transient failures are retried")
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.GreaterOrEqual(t, calls.Load(), int32(3), "the endpoint should have been retried")
+	})
+
+	t.Run("should not retry when no retry block is configured", func(t *testing.T) {
+		t.Parallel()
+
+		// given: the endpoint always returns 503
+		var calls atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls.Add(1)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		it := &HTTPRequestResource{}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolNull(),
+			RequestTimeoutMs: types.Int64Null(),
+			Retry:            types.ObjectNull(retryObjectAttrTypes()),
+		}
+		client := it.getHTTPClient(context.Background(), model)
+
+		// when
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+
+		// then
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, int32(1), calls.Load(),
+			"the endpoint should be called exactly once without retries")
+	})
+}
+
+func TestGetHTTPClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should fail fast when the response exceeds the timeout", func(t *testing.T) {
+		t.Parallel()
+
+		// given: the endpoint is slower than the configured timeout
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		it := &HTTPRequestResource{}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolNull(),
+			RequestTimeoutMs: types.Int64Value(50),
+			Retry:            types.ObjectNull(retryObjectAttrTypes()),
+		}
+		client := it.getHTTPClient(context.Background(), model)
+
+		// when
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		start := time.Now()
+		_, err = client.Do(req)
+
+		// then
+		require.Error(t, err, "the request must not hang; it should time out")
+		assert.Less(t, time.Since(start), 200*time.Millisecond,
+			"the client should give up well before the server responds")
+	})
+
+	t.Run("should not set a timeout when request_timeout_ms is unset", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		it := &HTTPRequestResource{}
+		model := HTTPRequestResourceModel{
+			IgnoreTLS:        types.BoolNull(),
+			RequestTimeoutMs: types.Int64Null(),
+			Retry:            types.ObjectNull(retryObjectAttrTypes()),
+		}
+
+		// when
+		client := it.getHTTPClient(context.Background(), model)
+
+		// then
+		assert.Equal(t, time.Duration(0), client.Timeout,
+			"an unset timeout preserves the historical no-timeout behavior")
+	})
+}

--- a/test/infrastructure/builders/provider_type_builder.go
+++ b/test/infrastructure/builders/provider_type_builder.go
@@ -3,11 +3,28 @@ package builders
 import "github.com/hashicorp/terraform-plugin-go/tftypes"
 
 const (
-	attrBasicAuth = "basic_auth"
-	attrIgnoreTLS = "ignore_tls"
-	attrUsername  = "username"
-	attrPassword  = "password"
+	attrBasicAuth        = "basic_auth"
+	attrIgnoreTLS        = "ignore_tls"
+	attrUsername         = "username"
+	attrPassword         = "password"
+	attrRequestTimeoutMs = "request_timeout_ms"
+	attrRetry            = "retry"
+	attrAttempts         = "attempts"
+	attrMinDelayMs       = "min_delay_ms"
+	attrMaxDelayMs       = "max_delay_ms"
 )
+
+// retryObjectType is the tftypes shape of the `retry` nested block, shared by the
+// provider and resource type builders.
+func retryObjectType() tftypes.Object {
+	return tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			attrAttempts:   tftypes.Number,
+			attrMinDelayMs: tftypes.Number,
+			attrMaxDelayMs: tftypes.Number,
+		},
+	}
+}
 
 type ProviderTypeBuilder struct {
 	attributeTypes map[string]tftypes.Type
@@ -58,6 +75,16 @@ func (b *ProviderTypeBuilder) WithPassword() *ProviderTypeBuilder {
 
 func (b *ProviderTypeBuilder) WithIgnoreTLS() *ProviderTypeBuilder {
 	b.attributeTypes[attrIgnoreTLS] = tftypes.Bool
+	return b
+}
+
+func (b *ProviderTypeBuilder) WithRequestTimeoutMs() *ProviderTypeBuilder {
+	b.attributeTypes[attrRequestTimeoutMs] = tftypes.Number
+	return b
+}
+
+func (b *ProviderTypeBuilder) WithRetry() *ProviderTypeBuilder {
+	b.attributeTypes[attrRetry] = retryObjectType()
 	return b
 }
 

--- a/test/infrastructure/builders/resource_type_builder.go
+++ b/test/infrastructure/builders/resource_type_builder.go
@@ -52,6 +52,16 @@ func (b *ResourceTypeBuilder) WithQueryParameters() *ResourceTypeBuilder {
 	return b
 }
 
+func (b *ResourceTypeBuilder) WithRequestTimeoutMs() *ResourceTypeBuilder {
+	b.attributeTypes[attrRequestTimeoutMs] = tftypes.Number
+	return b
+}
+
+func (b *ResourceTypeBuilder) WithRetry() *ResourceTypeBuilder {
+	b.attributeTypes[attrRetry] = retryObjectType()
+	return b
+}
+
 func (b *ResourceTypeBuilder) WithIsDeleteEnabled() *ResourceTypeBuilder {
 	b.attributeTypes["is_delete_enabled"] = tftypes.Bool
 	return b


### PR DESCRIPTION
## Summary

The HTTP client built by the provider set no `Timeout` and performed no retries, so a request against a slow or unreachable endpoint could **hang indefinitely**, and a transient failure would fail the apply outright.

This adds a configurable per-request timeout and retry, mirroring the upstream [`hashicorp/http`](https://registry.terraform.io/providers/hashicorp/http/latest/docs) provider so the API feels familiar:

- **`request_timeout_ms`** (Number) — bounds each individual attempt. Unset or `0` preserves the previous behavior (no timeout).
- **`retry`** block — `attempts`, `min_delay_ms` (default `1000`), `max_delay_ms` (default `30000`). Retries are attempted on connection errors and on 5xx responses (except 501) using an exponential backoff.

Both are available at the **provider** level (apply to every request) and at the **resource** level (override the provider defaults). Retries are implemented with `github.com/hashicorp/go-retryablehttp` — the same library `hashicorp/http` uses — promoted from an indirect to a direct dependency.

```hcl
provider "http" {
  url                = "https://api.example.com"
  request_timeout_ms = 60000

  retry {
    attempts = 5
  }
}
```

## Implementation notes

- `getHTTPClient` now resolves the effective TLS / timeout / retry settings (resource overrides provider) and builds the client accordingly. With no retry configured it returns a plain client, so behavior is unchanged when the new arguments are unset.
- `request_timeout_ms` and `retry` are intentionally **excluded from `RequestAttributesChanged`**, so changing them is an in-place update and never re-issues the request (important for non-idempotent methods).
- They are carried as **typed nulls** through the `v0`→`v1` state upgrader and the Base64 import path, avoiding the "missing type" conversion-error class previously fixed for the delete attributes.
- The `docs/` change was applied by hand to add only the two new attributes. A full `tfplugindocs` regen currently also drops a stale `tolerated_status_codes` example that the committed docs still carry but `examples/resources/http_request/resource.tf` no longer contains — left out here to keep this PR focused on the feature.

## Tests

- retry-on-5xx eventually succeeds; with no `retry` block the endpoint is called exactly once.
- `request_timeout_ms` fails fast instead of hanging; unset ⇒ no client timeout.
- `retryConfigFromObject` default/clamp behavior; `RequestAttributesChanged` proves timeout/retry never trigger a re-issue.
- `make test` and `make lint` pass locally.

## :vertical_traffic_light: Quality checklist

- [x] Did you add the changes in the `CHANGELOG.md`?
- [x] Did you run all the code checks? (`make test`, `make docs`)
- [x] Are the tests passing?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
