### PR TITLE
chore(bump): bumped version to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-06-29
+
 ### Added
 
 - added a `request_timeout_ms` argument and a `retry` block (`attempts`, `min_delay_ms`, `max_delay_ms`) to both the provider and the `http_request` resource, mirroring the upstream `hashicorp/http` provider. Configured at the provider level they apply to every request; the matching resource-level arguments override them. `request_timeout_ms` bounds each individual attempt -- an unset or `0` value preserves the previous behavior of waiting indefinitely -- and retries are attempted on connection errors and on 5xx (except 501) responses using an exponential backoff bounded by `min_delay_ms` and `max_delay_ms`. This addresses requests hanging indefinitely against a slow or unreachable endpoint, since the underlying HTTP client previously set no timeout and performed no retries
 
 ### Changed
 
-- promoted `github.com/hashicorp/go-retryablehttp` to a direct dependency, used to implement the new request `retry` support
 - changed the Go module dependencies to their latest versions
+- promoted `github.com/hashicorp/go-retryablehttp` to a direct dependency, used to implement the new request `retry` support
 
 ### Fixed
 


### PR DESCRIPTION
Release `3.3.0`. Moves the `[Unreleased]` entries into a dated `## [3.3.0]` section.

Highlights:
- **Added** configurable `request_timeout_ms` + `retry` block on the provider and the `http_request` resource (mirrors `hashicorp/http`).
- **Fixed** connection-pool reuse when `ignore_tls` is enabled at the provider level.
- **Changed** promoted `go-retryablehttp` to a direct dependency; dependency refresh.

## :vertical_traffic_light: Quality checklist

- [x] Did you update the unreleased section on `CHANGELOG.md` with a version number and date?
- [ ] ~~Did you update the `version` constant in the `main.go` file?~~ N/A — version is injected via `ldflags` (`main.version`), no hardcoded constant.
- [ ] ~~Did you update the `VERSION` variable in the `Makefile`?~~ N/A — `Makefile` auto-detects `VERSION` from the latest git tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
