### PR TITLE
fix(mapper): rendered whole JSON numbers without scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `response_body_id`, `delete_resolved_path` and `response_body_json` recording whole JSON
+  numbers in scientific notation (an id of `803554429` became `8.03554429e+08`), which broke every
+  consumer that interpolated the value back into a request -- most visibly `delete_path`, leaving
+  affected resources impossible to destroy. Whole numbers within the exactly-representable float64
+  range are now rendered positionally; fractional numbers, booleans, strings and JSON null keep
+  their previous rendering
+- fixed already-written state carrying the notation above: the resource schema moves to version 2
+  and a state upgrader rewrites the three attributes in place, driven by the numbers in each
+  resource's own recorded `response_body` so nothing is guessed
+
 ## [3.3.8] - 2026-07-28
 
 ### Changed

--- a/internal/infrastructure/helpers/mapper_helper.go
+++ b/internal/infrastructure/helpers/mapper_helper.go
@@ -1,6 +1,16 @@
 package helpers
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// MaxExactJSONInteger is the largest magnitude (2^53) that a float64 represents exactly.
+// Above it, consecutive integers are no longer distinguishable, so rendering such a value
+// in positional notation would invent digits that were never in the payload.
+const MaxExactJSONInteger = 1 << 53
 
 func ConvertToStringMap(input map[string]any) map[string]string {
 	stringMap := make(map[string]string)
@@ -12,8 +22,45 @@ func ConvertToStringMap(input map[string]any) map[string]string {
 				stringMap[fmt.Sprintf("%s.%s", key, nestedKey)] = nestedValue
 			}
 		default:
-			stringMap[key] = fmt.Sprintf("%v", value)
+			stringMap[key] = FormatJSONScalar(value)
 		}
 	}
 	return stringMap
+}
+
+// FormatJSONScalar renders a value decoded from a JSON document as a string, keeping whole
+// numbers in positional notation.
+//
+// `encoding/json` decodes every JSON number into a float64, and the `%v` verb formats a
+// float64 with `%g`, which switches to scientific notation once the exponent grows. An
+// identifier such as 803554429 is therefore rendered as "8.03554429e+08" -- a string that no
+// longer works where the original number did: it cannot be interpolated into a URL path,
+// compared against the upstream value, or parsed by a strict consumer.
+//
+// Whole numbers within the exactly-representable range are formatted with the 'f' verb and
+// shortest-round-trip precision, which never emits an exponent. Every other value (including
+// fractional numbers, JSON null, booleans and strings) keeps the previous `%v` rendering, so
+// values already recorded in state stay byte-identical.
+func FormatJSONScalar(value any) string {
+	switch typed := value.(type) {
+	case json.Number:
+		// Only produced when the caller opts into json.Decoder.UseNumber; the original
+		// literal is already exact, so hand it back untouched.
+		return typed.String()
+	case float64:
+		return formatJSONFloat(typed)
+	case float32:
+		return formatJSONFloat(float64(typed))
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func formatJSONFloat(value float64) string {
+	// NaN and both infinities fail the equality or the range check and fall through to %v,
+	// which spells them out instead of pretending they are digits.
+	if value == math.Trunc(value) && math.Abs(value) <= MaxExactJSONInteger {
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%v", value)
 }

--- a/internal/infrastructure/helpers/mapper_helper_test.go
+++ b/internal/infrastructure/helpers/mapper_helper_test.go
@@ -1,0 +1,154 @@
+package helpers_test
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/rios0rios0/terraform-provider-http/internal/infrastructure/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatJSONScalar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should render a whole number in positional notation when %g would use an exponent", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		// the float64 encoding/json produces for the JSON number 803554429
+		value := any(803554429.0)
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "803554429", result)
+	})
+
+	t.Run("should drop no significant digit when the whole number ends in zero", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		value := any(803554430.0)
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "803554430", result)
+	})
+
+	t.Run("should keep a small whole number unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		value := any(27164.0)
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "27164", result)
+	})
+
+	t.Run("should keep a fractional number rendered as before", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		value := any(1.5)
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "1.5", result)
+	})
+
+	t.Run("should keep a whole number beyond exact float64 range rendered as before", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		// past 2^53 consecutive integers are indistinguishable, so positional
+		// notation would invent digits that were never in the payload
+		value := any(math.Pow(2, 60))
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "1.152921504606847e+18", result)
+	})
+
+	t.Run("should return the original literal when the number was decoded with UseNumber", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		value := any(json.Number("803554429"))
+
+		// when
+		result := helpers.FormatJSONScalar(value)
+
+		// then
+		assert.Equal(t, "803554429", result)
+	})
+
+	t.Run("should keep non-numeric values rendered as before", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		cases := map[string]struct {
+			value    any
+			expected string
+		}{
+			"string":    {value: "already-a-string", expected: "already-a-string"},
+			"boolean":   {value: true, expected: "true"},
+			"json null": {value: nil, expected: "<nil>"},
+		}
+
+		for name, testCase := range cases {
+			// when
+			result := helpers.FormatJSONScalar(testCase.value)
+
+			// then
+			assert.Equal(t, testCase.expected, result, name)
+		}
+	})
+}
+
+func TestConvertToStringMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should render an identifier positionally when the response body is decoded", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var decoded map[string]any
+		err := json.Unmarshal([]byte(`{"id":803554429,"title":"example"}`), &decoded)
+		require.NoError(t, err)
+
+		// when
+		result := helpers.ConvertToStringMap(decoded)
+
+		// then
+		assert.Equal(t, "803554429", result["id"])
+		assert.Equal(t, "example", result["title"])
+	})
+
+	t.Run("should flatten a nested object using dot notation", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		var decoded map[string]any
+		err := json.Unmarshal([]byte(`{"data":{"id":803554429,"nested":{"count":2}}}`), &decoded)
+		require.NoError(t, err)
+
+		// when
+		result := helpers.ConvertToStringMap(decoded)
+
+		// then
+		assert.Equal(t, "803554429", result["data.id"])
+		assert.Equal(t, "2", result["data.nested.count"])
+	})
+}

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -1099,10 +1099,16 @@ func repairExponentNotation(
 	}
 
 	// The resolved path embeds the rendering inside a larger string, so substitute in place.
+	// One rendering can be a substring of another -- "1e+08" sits inside "1.1e+08" -- and Go
+	// randomises map iteration, so substituting the shorter one first would turn
+	// "/posts/1.1e+08" into "/posts/1.100000000" on some runs and not others. Applying the
+	// longest rendering first removes both the corruption and the non-determinism. Every
+	// replacement value is digits only while every rendering carries an exponent, so a
+	// substitution can never produce text that a later rendering matches.
 	if !model.DeleteResolvedPath.IsNull() {
 		repaired := model.DeleteResolvedPath.ValueString()
-		for old, updated := range replacements {
-			repaired = strings.ReplaceAll(repaired, old, updated)
+		for _, rendering := range renderingsLongestFirst(replacements) {
+			repaired = strings.ReplaceAll(repaired, rendering, replacements[rendering])
 		}
 		model.DeleteResolvedPath = types.StringValue(repaired)
 	}
@@ -1115,6 +1121,24 @@ func repairExponentNotation(
 			model.ResponseBodyJSON = rebuilt
 		}
 	}
+}
+
+// renderingsLongestFirst returns the old renderings ordered longest first, ties broken
+// lexicographically so the sequence is stable across runs.
+func renderingsLongestFirst(replacements map[string]string) []string {
+	renderings := make([]string, 0, len(replacements))
+	for rendering := range replacements {
+		renderings = append(renderings, rendering)
+	}
+
+	slices.SortFunc(renderings, func(left, right string) int {
+		if byLength := len(right) - len(left); byLength != 0 {
+			return byLength
+		}
+		return strings.Compare(left, right)
+	})
+
+	return renderings
 }
 
 // collectExponentRenderings walks a decoded JSON document and records, for every number whose

--- a/internal/provider/resource_http_request.go
+++ b/internal/provider/resource_http_request.go
@@ -46,6 +46,14 @@ var (
 
 const AmountOfPartsInID = 2
 
+// Schema versions of the http_request resource. Version 2 is shape-identical to version 1; the
+// bump exists so a state upgrader can rewrite captured numbers that version 1 recorded in
+// scientific notation.
+const (
+	schemaVersionV1 = 1
+	schemaVersionV2 = 2
+)
+
 const deleteParamsPrivateKey = "delete_params"
 
 type deleteParamsPrivate struct {
@@ -227,11 +235,31 @@ func GetHTTPRequestResourceSchema() schema.Schema {
 	addStateAttributes(attrs)
 
 	return schema.Schema{
-		Version: 1,
+		Version: schemaVersionV2,
 		Description: "Represents an HTTP request resource, allowing configuration of various " +
 			"HTTP request parameters and capturing the response details.",
 		MarkdownDescription: "Represents an HTTP request resource, allowing configuration of various " +
 			"HTTP request parameters and capturing the response details.",
+		Attributes: attrs,
+		Blocks: map[string]schema.Block{
+			attrRetry: resourceRetryBlock(),
+		},
+	}
+}
+
+// getHTTPRequestResourceSchemaV1 returns the schema as it stood in version 1. Version 2 is
+// shape-identical -- the bump exists only so the upgrader below can rewrite captured numbers
+// that version 1 recorded in scientific notation -- so the same attribute builders are reused.
+func getHTTPRequestResourceSchemaV1() schema.Schema {
+	attrs := make(map[string]schema.Attribute)
+	addRequestAttributes(attrs)
+	addResourceConfigAttributes(attrs)
+	addRetryTimeoutAttributes(attrs)
+	addDeleteControlAttributes(attrs)
+	addStateAttributes(attrs)
+
+	return schema.Schema{
+		Version:    schemaVersionV1,
 		Attributes: attrs,
 		Blocks: map[string]schema.Block{
 			attrRetry: resourceRetryBlock(),
@@ -949,6 +977,8 @@ func (it *HTTPRequestResource) UpgradeState(_ context.Context) map[int64]resourc
 		Attributes: v0Attrs,
 	}
 
+	v1Schema := getHTTPRequestResourceSchemaV1()
+
 	return map[int64]resource.StateUpgrader{
 		0: {
 			PriorSchema: &v0Schema,
@@ -1001,6 +1031,109 @@ func (it *HTTPRequestResource) UpgradeState(_ context.Context) map[int64]resourc
 				resp.Diagnostics.Append(resp.State.Set(ctx, newModel)...)
 			},
 		},
+		1: {
+			PriorSchema: &v1Schema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var model HTTPRequestResourceModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				repairExponentNotation(ctx, &model, &resp.Diagnostics)
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, model)...)
+			},
+		},
+	}
+}
+
+// RepairExponentNotation applies the schema v1 -> v2 captured-number repair to a model
+// (exported for testing).
+func RepairExponentNotation(
+	ctx context.Context,
+	model *HTTPRequestResourceModel,
+	diagnostics *diag.Diagnostics,
+) {
+	repairExponentNotation(ctx, model, diagnostics)
+}
+
+// repairExponentNotation rewrites the captured attributes that schema version 1 rendered with
+// the `%v` verb. Applied to the float64 that `encoding/json` produces for every JSON number,
+// `%v` formats with `%g` and switches to scientific notation once the exponent grows, so a
+// nine-digit identifier such as 803554429 was recorded as "8.03554429e+08".
+//
+// Three attributes carried the damage: `response_body_id`, `delete_resolved_path` (the id is
+// substituted into the path, and Destroy prefers the stored value over re-resolving it, so a
+// corrupted path makes the resource undeletable) and the `response_body_json` map.
+//
+// The repair is driven by the resource's own recorded `response_body`: every number in it is
+// rendered both the old way and the new way, and only those exact renderings are substituted.
+// Nothing is guessed, and a response body that no longer parses leaves the state untouched.
+func repairExponentNotation(
+	ctx context.Context,
+	model *HTTPRequestResourceModel,
+	diagnostics *diag.Diagnostics,
+) {
+	if model.ResponseBody.IsNull() || model.ResponseBody.ValueString() == "" {
+		return
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(model.ResponseBody.ValueString()), &decoded); err != nil {
+		return
+	}
+
+	replacements := make(map[string]string)
+	collectExponentRenderings(decoded, replacements)
+	if len(replacements) == 0 {
+		return
+	}
+
+	// The id is a single scalar rendering, so require an exact match rather than a substring
+	// one -- that cannot corrupt an id that merely contains a number as a substring.
+	if !model.ResponseBodyID.IsNull() {
+		if repaired, found := replacements[model.ResponseBodyID.ValueString()]; found {
+			model.ResponseBodyID = types.StringValue(repaired)
+		}
+	}
+
+	// The resolved path embeds the rendering inside a larger string, so substitute in place.
+	if !model.DeleteResolvedPath.IsNull() {
+		repaired := model.DeleteResolvedPath.ValueString()
+		for old, updated := range replacements {
+			repaired = strings.ReplaceAll(repaired, old, updated)
+		}
+		model.DeleteResolvedPath = types.StringValue(repaired)
+	}
+
+	// The map is derived wholesale from the response body, so simply rebuild it.
+	if model.IsResponseBodyJSON.ValueBool() {
+		rebuilt, diags := types.MapValueFrom(ctx, types.StringType, helpers.ConvertToStringMap(decoded))
+		diagnostics.Append(diags...)
+		if !diags.HasError() {
+			model.ResponseBodyJSON = rebuilt
+		}
+	}
+}
+
+// collectExponentRenderings walks a decoded JSON document and records, for every number whose
+// rendering changed between schema versions, the old rendering mapped to the new one.
+func collectExponentRenderings(value any, replacements map[string]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, nested := range typed {
+			collectExponentRenderings(nested, replacements)
+		}
+	case []any:
+		for _, nested := range typed {
+			collectExponentRenderings(nested, replacements)
+		}
+	default:
+		previous := fmt.Sprintf("%v", value)
+		if current := helpers.FormatJSONScalar(value); current != previous {
+			replacements[previous] = current
+		}
 	}
 }
 
@@ -1251,7 +1384,7 @@ func updateResponseBodyID(
 
 	element := jsonPath.First(jsonResponse)
 	if element != nil {
-		model.ResponseBodyID = types.StringValue(fmt.Sprintf("%v", element))
+		model.ResponseBodyID = types.StringValue(helpers.FormatJSONScalar(element))
 	} else {
 		diagnostics.AddWarning("The JSON path provided didn't return any value...",
 			"Please check the `response_body_id_filter` provided.")
@@ -1337,7 +1470,7 @@ func resolveDeletePathTokens(rawPath, responseBody string, diagnostics *diag.Dia
 				fmt.Sprintf("token: %q did not resolve against create response", token))
 			return "", false
 		}
-		repl := fmt.Sprintf("%v", val)
+		repl := helpers.FormatJSONScalar(val)
 		resolved = strings.ReplaceAll(resolved, token, repl)
 	}
 

--- a/internal/provider/resource_http_request_upgrade_test.go
+++ b/internal/provider/resource_http_request_upgrade_test.go
@@ -1,0 +1,202 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rios0rios0/terraform-provider-http/internal/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+// baselineUpgradeModel returns a schema v1 state as the provider used to write it: the
+// create response carried the numeric id 803554429, and every attribute derived from it was
+// rendered with an exponent.
+func baselineUpgradeModel() provider.HTTPRequestResourceModel {
+	return provider.HTTPRequestResourceModel{
+		Method:               types.StringValue("POST"),
+		Path:                 types.StringValue("/posts"),
+		IsResponseBodyJSON:   types.BoolValue(true),
+		ResponseBodyIDFilter: types.StringValue("$.id"),
+		ResponseBody:         types.StringValue(`{"id":803554429,"title":"example","views":60}`),
+		ResponseBodyID:       types.StringValue("8.03554429e+08"),
+		DeleteResolvedPath:   types.StringValue("/posts/8.03554429e+08"),
+		ResponseBodyJSON: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"id":    types.StringValue("8.03554429e+08"),
+			"title": types.StringValue("example"),
+			"views": types.StringValue("60"),
+		}),
+	}
+}
+
+func TestRepairExponentNotation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should rewrite the captured id positionally when state holds an exponent", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "803554429", model.ResponseBodyID.ValueString())
+	})
+
+	t.Run("should rewrite the resolved delete path so destroy addresses a real id", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "/posts/803554429", model.DeleteResolvedPath.ValueString())
+	})
+
+	t.Run("should rebuild the response body map when the body is flagged as JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		rebuilt := model.ResponseBodyJSON.Elements()
+		assert.Equal(t, types.StringValue("803554429"), rebuilt["id"])
+		assert.Equal(t, types.StringValue("example"), rebuilt["title"])
+		assert.Equal(t, types.StringValue("60"), rebuilt["views"])
+	})
+
+	t.Run("should leave state untouched when no captured number changed rendering", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringValue(`{"id":27164,"title":"group"}`)
+		model.ResponseBodyID = types.StringValue("27164")
+		model.DeleteResolvedPath = types.StringValue("/groups/27164")
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "27164", model.ResponseBodyID.ValueString())
+		assert.Equal(t, "/groups/27164", model.DeleteResolvedPath.ValueString())
+	})
+
+	t.Run("should leave state untouched when the recorded response body is not JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringValue("Created")
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "8.03554429e+08", model.ResponseBodyID.ValueString())
+		assert.Equal(t, "/posts/8.03554429e+08", model.DeleteResolvedPath.ValueString())
+	})
+
+	t.Run("should leave state untouched when no response body was recorded", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringNull()
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "8.03554429e+08", model.ResponseBodyID.ValueString())
+	})
+
+	t.Run("should not substitute an id that only contains the old rendering as a substring", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBodyID = types.StringValue("prefix-8.03554429e+08")
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "prefix-8.03554429e+08", model.ResponseBodyID.ValueString())
+	})
+
+	t.Run("should rewrite an id nested inside the recorded response body", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringValue(`{"data":{"post":{"id":803554429}}}`)
+		model.ResponseBodyIDFilter = types.StringValue("$.data.post.id")
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "803554429", model.ResponseBodyID.ValueString())
+	})
+
+	t.Run("should rewrite an id carried inside a response body array", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringValue(`{"data":[{"id":803554429}]}`)
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "803554429", model.ResponseBodyID.ValueString())
+	})
+}
+
+func TestGetHTTPRequestResourceSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should declare version 2 so the captured-number repair runs once", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		// the schema as the provider advertises it
+
+		// when
+		result := provider.GetHTTPRequestResourceSchema()
+
+		// then
+		assert.Equal(t, int64(2), result.Version)
+	})
+}

--- a/internal/provider/resource_http_request_upgrade_test.go
+++ b/internal/provider/resource_http_request_upgrade_test.go
@@ -167,6 +167,28 @@ func TestRepairExponentNotation(t *testing.T) {
 		assert.Equal(t, "803554429", model.ResponseBodyID.ValueString())
 	})
 
+	t.Run("should substitute the longest rendering first when one is a substring of another", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		// "1e+08" (from 100000000) is a substring of "1.1e+08" (from 110000000), so
+		// substituting the shorter rendering first would yield "/posts/1.100000000".
+		// Go randomises map iteration, so an unordered loop fails this only sometimes.
+		model := baselineUpgradeModel()
+		model.ResponseBody = types.StringValue(`{"id":110000000,"sibling":100000000}`)
+		model.ResponseBodyID = types.StringValue("1.1e+08")
+		model.DeleteResolvedPath = types.StringValue("/posts/1.1e+08")
+		var diagnostics diag.Diagnostics
+
+		// when
+		provider.RepairExponentNotation(context.Background(), &model, &diagnostics)
+
+		// then
+		assert.False(t, diagnostics.HasError())
+		assert.Equal(t, "/posts/110000000", model.DeleteResolvedPath.ValueString())
+		assert.Equal(t, "110000000", model.ResponseBodyID.ValueString())
+	})
+
 	t.Run("should rewrite an id carried inside a response body array", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Problem

`encoding/json` decodes every JSON number into a `float64`, and the `%v` verb formats a `float64` with `%g`, which switches to scientific notation once the exponent grows. Three captured attributes were built with `fmt.Sprintf("%v", ...)`, so a nine-digit identifier returned by an API was recorded as `8.03554429e+08` instead of `803554429`:

- `response_body_id`
- `delete_resolved_path`
- the `response_body_json` map

The consequence is worse than cosmetic. `delete_path` substitutes the captured id into the path, and `Delete` prefers the stored `delete_resolved_path` over re-resolving it, so an affected resource sends `DELETE /posts/8.03554429e+08` — an address no API accepts. **The resource can never be destroyed**, and `-replace` cannot recover it either. Any configuration interpolating `response_body_id` into a later request is broken the same way.

Whole numbers only reach an exponent above a certain magnitude, so small ids were unaffected and the bug stayed invisible until an API started handing out large ones.

## Change

- `helpers.FormatJSONScalar` renders a whole number within the exactly-representable `float64` range (≤ 2^53) with the `'f'` verb and shortest-round-trip precision, which never emits an exponent. Beyond 2^53 consecutive integers are indistinguishable, so those keep the `%v` rendering rather than inventing digits that were never in the payload.
- Used at the three sites above.
- Fractional numbers, booleans, strings and JSON null keep their previous rendering, so values already recorded in state stay byte-identical.

## Repairing existing state

A formatter fix only affects new writes, and this resource has no `Read` that would recompute the captured attributes, so state already written would stay corrupt — and undeletable. The resource schema therefore moves to **version 2** with a state upgrader that rewrites the three attributes in place.

The repair is driven by each resource's own recorded `response_body`: every number in it is rendered both the old way and the new way, and only those exact renderings are substituted. Nothing is guessed. A response body that no longer parses, or one with no affected number, leaves the state untouched. The id is matched exactly (not as a substring) so an id that merely contains a number cannot be corrupted.

Version 2 is shape-identical to version 1 — the bump exists purely to run the repair once.

## Tests

`make lint` clean, `go test ./internal/...` green. New BDD-style cases cover:

- whole number past the exponent switch → positional; trailing zero not dropped
- small whole number, fractional number, string, boolean and JSON null unchanged
- past 2^53 keeps the previous rendering
- `json.Number` passthrough
- upgrader rewrites `response_body_id`, `delete_resolved_path` and rebuilds `response_body_json`
- upgrader is a no-op for unaffected bodies, non-JSON bodies and absent bodies
- upgrader does not substitute an id that only contains the old rendering as a substring
- ids nested in an object and inside an array are found

Verified non-tautological: reverting the formatter to `%v` fails the new assertions.