### PR TITLE
chore(bump): bumped version to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-08-06
+
 ### Added
 
 - added a provider-level `headers` map, sent on every request the provider makes and applied BEFORE


### PR DESCRIPTION
## Summary

This PR bumps the version to **3.5.0** for project **terraform-provider-http**.

**MINOR**, because `[Unreleased]` carries an `### Added` section: the provider-level `headers` map from #192. Nothing in it is breaking — the attribute is optional and absent by default, the resource schema is untouched (so no state migration and no new upgrader), and no existing configuration changes behaviour.

### Changes

- Updated `CHANGELOG.md` with the new version and date

### Review Checklist

- [ ] Verify build passes
- [ ] Verify tests pass
- [ ] Review changelog entries

---

### Note: two AutoBump edits were corrected by hand

AutoBump produced the version heading correctly but damaged two of the wrapped entries, because it treats each **line** as a bullet rather than each bullet as a wrapped block. Both were repaired before this PR was opened, so the diff against `main` is now exactly one inserted heading and nothing else.

1. **A bullet was inserted into the middle of another one.** It moved `- changed the Go module dependencies to their latest versions` from the first position in `### Changed` to the second — landing it *between* the first line of the `ValidateConfig` entry and that entry's continuation lines, orphaning them:

   ```markdown
   - changed the `ValidateConfig` tests to build their provider value through `fullProviderValues`,
   - changed the Go module dependencies to their latest versions
     `basicAuthValue` and `validateConfigOf` instead of spelling the whole six-attribute object ...
   ```

2. **The last continuation line of the final entry was dropped.** The `### Fixed` bullet lost its closing `  one`, ending the sentence mid-phrase at "...rather than on the new".

Worth noting because it is not specific to this release: any wrapped multi-line entry is at risk, and the `[3.4.0]` section is wrapped the same way. The wrapping itself is the repo's convention — every section since `3.3.x` wraps at 100 characters, and the reviewer on #192 asked for it explicitly — so the fix belongs in AutoBump's changelog parser rather than in how entries are written here.
